### PR TITLE
Provide row indexset when building sparsity pattern

### DIFF
--- a/include/inclusions.h
+++ b/include/inclusions.h
@@ -27,6 +27,8 @@
 
 #include <deal.II/physics/transformations.h>
 
+#include <boost/algorithm/string.hpp>
+
 #include <fstream>
 
 using namespace dealii;

--- a/include/laplacian.h
+++ b/include/laplacian.h
@@ -196,7 +196,7 @@ public:
   print_parameters() const;
 
 private:
-  const ProblemParameters<dim, spacedim> &       par;
+  const ProblemParameters<dim, spacedim>        &par;
   MPI_Comm                                       mpi_communicator;
   ConditionalOStream                             pcout;
   mutable TimerOutput                            computing_timer;

--- a/source/elasticity.cc
+++ b/source/elasticity.cc
@@ -131,9 +131,9 @@ ElasticityProblem<dim, spacedim>::make_grid()
       gi.attach_triangulation(tria);
 #ifdef DEAL_II_WITH_GMSH_API
       std::string infile(par.name_of_grid);
-      Assert(!infile.empty(), ExcIO());
 #else
       std::ifstream infile(par.name_of_grid);
+      Assert(infile.good(), ExcIO());
 #endif
       try
         {

--- a/source/elasticity.cc
+++ b/source/elasticity.cc
@@ -129,9 +129,12 @@ ElasticityProblem<dim, spacedim>::make_grid()
     {
       GridIn<spacedim> gi;
       gi.attach_triangulation(tria);
-      // std::ifstream infile(par.name_of_grid);
-      const std::string infile(par.name_of_grid);
+#ifdef DEAL_II_WITH_GMSH_API
+      std::string infile(par.name_of_grid);
       Assert(!infile.empty(), ExcIO());
+#else
+      std::ifstream infile(par.name_of_grid);
+#endif
       try
         {
           gi.read_msh(infile);

--- a/source/laplacian.cc
+++ b/source/laplacian.cc
@@ -41,8 +41,8 @@ PoissonProblem<dim, spacedim>::PoissonProblem(
 
 template <int dim, int spacedim>
 void
-read_grid_and_cad_files(const std::string &           grid_file_name,
-                        const std::string &           ids_and_cad_file_names,
+read_grid_and_cad_files(const std::string            &grid_file_name,
+                        const std::string            &ids_and_cad_file_names,
                         Triangulation<dim, spacedim> &tria)
 {
   GridIn<dim, spacedim> grid_in;
@@ -166,7 +166,9 @@ PoissonProblem<dim, spacedim>::setup_dofs()
         complete_index_set(inclusions.n_coefficients));
 
       coupling_matrix.clear();
-      DynamicSparsityPattern dsp(dh.n_dofs(), inclusions.n_dofs());
+      DynamicSparsityPattern dsp(dh.n_dofs(),
+                                 inclusions.n_dofs(),
+                                 relevant_dofs[0]);
 
       relevant_dofs[1] = assemble_coupling_sparsity(dsp);
       SparsityTools::distribute_sparsity_pattern(dsp,
@@ -178,7 +180,9 @@ PoissonProblem<dim, spacedim>::setup_dofs()
                              dsp,
                              mpi_communicator);
 
-      DynamicSparsityPattern idsp(inclusions.n_dofs(), inclusions.n_dofs());
+      DynamicSparsityPattern idsp(inclusions.n_dofs(),
+                                  inclusions.n_dofs(),
+                                  relevant_dofs[1]);
       for (const auto i : owned_dofs[1])
         idsp.add(i, i);
 

--- a/tests/test_fourier_01.output
+++ b/tests/test_fourier_01.output
@@ -9,7 +9,7 @@ DEAL::sin(theta)*phi_0: -9.54098e-18
 DEAL::sin(theta)*phi_1: -9.54098e-18
 DEAL::sin(theta)*phi_2: 0.00000
 DEAL::integral 0: 3.14159
-DEAL::integral 1: 1.57080
+DEAL::integral 1: 3.14159
 DEAL::integral 2: 0.00000
 DEAL::cos(theta)*phi_0: 7.63278e-17
 DEAL::cos(theta)*phi_1: 3.81639e-17


### PR DESCRIPTION
Current master is not working  with latest deal.II version because `DynamicSparsityPattern` and `SparsityTools::distribute_sparsity_pattern` need to be given the index set of locally relevant rows. 

While there, I updated the deal.II test file