### PR TITLE
Bulk evaluator matrix-free

### DIFF
--- a/apps/app_laplacian.cc
+++ b/apps/app_laplacian.cc
@@ -33,12 +33,10 @@ main(int argc, char *argv[])
         prm_file = "parameters.prm";
       if (prm_file.find("23d") != std::string::npos)
         {
-#ifndef MATRIX_FREE_PATH
           ProblemParameters<2, 3> par;
           PoissonProblem<2, 3>    problem(par);
           ParameterAcceptor::initialize(prm_file);
           problem.run();
-#endif
         }
       else if (prm_file.find("3d") != std::string::npos)
         {

--- a/apps/app_laplacian.cc
+++ b/apps/app_laplacian.cc
@@ -33,10 +33,12 @@ main(int argc, char *argv[])
         prm_file = "parameters.prm";
       if (prm_file.find("23d") != std::string::npos)
         {
+#ifndef MATRIX_FREE_PATH
           ProblemParameters<2, 3> par;
           PoissonProblem<2, 3>    problem(par);
           ParameterAcceptor::initialize(prm_file);
           problem.run();
+#endif
         }
       else if (prm_file.find("3d") != std::string::npos)
         {

--- a/include/laplacian.h
+++ b/include/laplacian.h
@@ -175,6 +175,9 @@ public:
 #ifndef MATRIX_FREE_PATH
   void
   assemble_poisson_system();
+#else
+  void
+                        assemble_rhs();
 #endif
   void
   assemble_coupling();
@@ -225,8 +228,6 @@ private:
   MatrixFreeOperators::LaplaceOperator<dim, -1> stiffness_matrix;
   using VectorType      = LinearAlgebra::distributed::Vector<double>;
   using BlockVectorType = LinearAlgebra::distributed::BlockVector<double>;
-  void
-  assemble_rhs();
 #else
   LA::MPI::SparseMatrix stiffness_matrix;
   using VectorType      = LA::MPI::Vector;

--- a/include/laplacian.h
+++ b/include/laplacian.h
@@ -225,7 +225,7 @@ private:
   LA::MPI::SparseMatrix coupling_matrix;
   LA::MPI::SparseMatrix inclusion_matrix;
 #ifdef MATRIX_FREE_PATH
-  MatrixFreeOperators::LaplaceOperator<dim, -1> stiffness_matrix;
+  MatrixFreeOperators::LaplaceOperator<spacedim, -1> stiffness_matrix;
   using VectorType      = LinearAlgebra::distributed::Vector<double>;
   using BlockVectorType = LinearAlgebra::distributed::BlockVector<double>;
 #else

--- a/include/laplacian.h
+++ b/include/laplacian.h
@@ -10,8 +10,11 @@
 
 #include <deal.II/lac/block_linear_operator.h>
 #include <deal.II/lac/generic_linear_algebra.h>
+#include <deal.II/lac/la_parallel_block_vector.h>
 #include <deal.II/lac/linear_operator.h>
 #include <deal.II/lac/linear_operator_tools.h>
+#define MATRIX_FREE_PATH
+
 #define FORCE_USE_OF_TRILINOS
 namespace LA
 {
@@ -63,6 +66,8 @@ namespace LA
 #include <deal.II/lac/solver_minres.h>
 #include <deal.II/lac/sparsity_tools.h>
 #include <deal.II/lac/vector.h>
+
+#include <deal.II/matrix_free/operators.h>
 
 #include <deal.II/numerics/data_out.h>
 #include <deal.II/numerics/error_estimator.h>
@@ -167,8 +172,10 @@ public:
   setup_fe();
   void
   setup_dofs();
+#ifndef MATRIX_FREE_PATH
   void
   assemble_poisson_system();
+#endif
   void
   assemble_coupling();
   void
@@ -204,19 +211,31 @@ private:
   std::unique_ptr<FiniteElement<spacedim>>       fe;
   Inclusions<spacedim>                           inclusions;
   std::unique_ptr<Quadrature<spacedim>>          quadrature;
-  DoFHandler<spacedim>                           dh;
-  std::vector<IndexSet>                          owned_dofs;
-  std::vector<IndexSet>                          relevant_dofs;
+
+  DoFHandler<spacedim>  dh;
+  std::vector<IndexSet> owned_dofs;
+  std::vector<IndexSet> relevant_dofs;
 
   AffineConstraints<double> constraints;
   AffineConstraints<double> inclusion_constraints;
 
-  LA::MPI::SparseMatrix                           stiffness_matrix;
-  LA::MPI::SparseMatrix                           coupling_matrix;
-  LA::MPI::SparseMatrix                           inclusion_matrix;
-  LA::MPI::BlockVector                            solution;
-  LA::MPI::BlockVector                            locally_relevant_solution;
-  LA::MPI::BlockVector                            system_rhs;
+  LA::MPI::SparseMatrix coupling_matrix;
+  LA::MPI::SparseMatrix inclusion_matrix;
+#ifdef MATRIX_FREE_PATH
+  MatrixFreeOperators::LaplaceOperator<dim, -1> stiffness_matrix;
+  using VectorType      = LinearAlgebra::distributed::Vector<double>;
+  using BlockVectorType = LinearAlgebra::distributed::BlockVector<double>;
+  void
+  assemble_rhs();
+#else
+  LA::MPI::SparseMatrix stiffness_matrix;
+  using VectorType      = LA::MPI::Vector;
+  using BlockVectorType = LA::MPI::BlockVector;
+#endif
+
+  BlockVectorType                                 solution;
+  BlockVectorType                                 locally_relevant_solution;
+  BlockVectorType                                 system_rhs;
   std::vector<std::vector<BoundingBox<spacedim>>> global_bounding_boxes;
   unsigned int                                    cycle = 0;
 };

--- a/source/laplacian.cc
+++ b/source/laplacian.cc
@@ -144,14 +144,14 @@ PoissonProblem<dim, spacedim>::setup_dofs()
   {
 #ifdef MATRIX_FREE_PATH
 
-    typename MatrixFree<dim, double>::AdditionalData additional_data;
+    typename MatrixFree<spacedim, double>::AdditionalData additional_data;
     additional_data.tasks_parallel_scheme =
-      MatrixFree<dim, double>::AdditionalData::none;
+      MatrixFree<spacedim, double>::AdditionalData::none;
     additional_data.mapping_update_flags =
       (update_gradients | update_JxW_values | update_quadrature_points);
-    std::shared_ptr<MatrixFree<dim, double>> system_mf_storage(
-      new MatrixFree<dim, double>());
-    system_mf_storage->reinit(MappingQ1<dim, spacedim>(),
+    std::shared_ptr<MatrixFree<spacedim, double>> system_mf_storage(
+      new MatrixFree<spacedim, double>());
+    system_mf_storage->reinit(MappingQ1<spacedim>(),
                               dh,
                               constraints,
                               QGauss<1>(fe->degree + 1),
@@ -450,7 +450,7 @@ PoissonProblem<dim, spacedim>::assemble_rhs()
   constraints.distribute(solution.block(0));
   solution.block(0).update_ghost_values();
 
-  FEEvaluation<dim, -1> phi(*stiffness_matrix.get_matrix_free());
+  FEEvaluation<spacedim, -1> phi(*stiffness_matrix.get_matrix_free());
   for (unsigned int cell = 0;
        cell < stiffness_matrix.get_matrix_free()->n_cell_batches();
        ++cell)
@@ -460,14 +460,14 @@ PoissonProblem<dim, spacedim>::assemble_rhs()
       phi.evaluate(EvaluationFlags::gradients);
       for (unsigned int q = 0; q < phi.n_q_points; ++q)
         {
-          const Point<dim, VectorizedArray<double>> p_vect =
+          const Point<spacedim, VectorizedArray<double>> p_vect =
             phi.quadrature_point(q);
 
           VectorizedArray<double> f_value = 0.0;
           for (unsigned int v = 0; v < VectorizedArray<double>::size(); ++v)
             {
-              Point<dim> p;
-              for (unsigned int d = 0; d < dim; ++d)
+              Point<spacedim> p;
+              for (unsigned int d = 0; d < spacedim; ++d)
                 p[d] = p_vect[d][v];
               f_value[v] = par.rhs.value(p);
             }
@@ -724,7 +724,5 @@ PoissonProblem<dim, spacedim>::run()
 
 // Template instantiations
 template class PoissonProblem<2>;
-#ifndef MATRIX_FREE_PATH
 template class PoissonProblem<2, 3>;
-#endif
 template class PoissonProblem<3>;


### PR DESCRIPTION
Integrates matrix-free evaluation for the bulk term. To this aim, a preprocessor macro `MATRIX_FREE_PATH` was added to conditionally define at compile time the necessary vector types `LA::d::V` or Trilinos/PETSc vectors. Actually, Trilinos vectors could be removed in favor of `LA::d::V` since the latter are compatible with mat-vec products.
Compared to the full matrix-based version, the changes are mostly related to the need to use different vector types and the definition of their parallel layout, as well as avoiding allocating the sparse matrix for the bulk term. 

The matrix-free action was wrapped in a linear operator object in order to have both versions in the same application file. The main difference at the moment is the absence of a preconditioner for the action of $A^{-1}$ in the matrix-free case: in the matrix-based case we just use AMG, here we should switch to a more classical CG+V-cycle of GMG for A.

I have also plans for the reduced operators $B$ and $B^T$ but they require considerably more work and will not be part of this PR (which is about the bulk term). 