### PR TITLE
Extract Rigid Body modes for AMG preconditioning

### DIFF
--- a/include/augmented_lagrangian_preconditioner.h
+++ b/include/augmented_lagrangian_preconditioner.h
@@ -1,5 +1,8 @@
+#include <deal.II/base/config.h>
 
 #include <deal.II/base/exceptions.h>
+
+#include <deal.II/dofs/dof_tools.h>
 
 #include <deal.II/lac/block_vector.h>
 #include <deal.II/lac/linear_operator.h>
@@ -171,6 +174,74 @@ namespace UtilitiesAL
     (void)augmented_matrix;
 #  endif
   }
+
+
+  /**
+   * @brief Set the null space of the matrix using a pre-computed set of
+   * vectors. Needed for the AMG preconditioner to work properly with linear
+   * elasticity. In particular, parameter_list will be filled by this function.
+   */
+  template <int spacedim>
+  void
+  set_null_space(Teuchos::ParameterList                 &parameter_list,
+                 std::unique_ptr<Epetra_MultiVector>    &ptr_distributed_modes,
+                 const Epetra_RowMatrix                 &matrix,
+                 const std::vector<std::vector<double>> &modes)
+  {
+    static_assert((spacedim == 2 || spacedim == 3),
+                  "This function only works for 2D and 3D.");
+
+#  ifdef DEAL_II_WITH_TRILINOS
+
+
+    using size_type = TrilinosWrappers::PreconditionAMG::size_type;
+    const Epetra_Map   &domain_map      = matrix.OperatorDomainMap();
+    constexpr size_type modes_dimension = spacedim == 3 ? 6 : 3;
+
+    ptr_distributed_modes.reset(
+      new Epetra_MultiVector(domain_map, modes_dimension));
+    Assert(ptr_distributed_modes, ExcNotInitialized());
+    Epetra_MultiVector &distributed_modes = *ptr_distributed_modes;
+
+    const size_type global_size = TrilinosWrappers::n_global_rows(matrix);
+
+    Assert(global_size == static_cast<size_type>(
+                            TrilinosWrappers::global_length(distributed_modes)),
+           ExcDimensionMismatch(
+             global_size, TrilinosWrappers::global_length(distributed_modes)));
+
+    const size_type my_size = domain_map.NumMyElements();
+
+    // Reshape null space as a contiguous vector of doubles so that
+    // Trilinos can read from it.
+    [[maybe_unused]] const size_type expected_mode_size = global_size;
+    for (size_type d = 0; d < modes_dimension; ++d)
+      {
+        Assert(modes[d].size() == expected_mode_size,
+               ExcDimensionMismatch(modes[d].size(), expected_mode_size));
+        for (size_type row = 0; row < my_size; ++row)
+          {
+            const TrilinosWrappers::types::int_type mode_index =
+              TrilinosWrappers::global_index(domain_map, row);
+            distributed_modes[d][row] =
+              static_cast<double>(modes[d][mode_index]);
+          }
+      }
+
+    parameter_list.set("null space: type", "pre-computed");
+    parameter_list.set("null space: dimension", distributed_modes.NumVectors());
+    parameter_list.set("null space: vectors", distributed_modes.Values());
+
+
+#  else
+    AssertThrow(
+      false,
+      ExcMessage(
+        "This function requires deal.II to be configured with Trilinos."));
+
+#  endif
+  }
+
 } // namespace UtilitiesAL
 
 #endif

--- a/include/augmented_lagrangian_preconditioner.h
+++ b/include/augmented_lagrangian_preconditioner.h
@@ -181,12 +181,12 @@ namespace UtilitiesAL
    * vectors. Needed for the AMG preconditioner to work properly with linear
    * elasticity. In particular, parameter_list will be filled by this function.
    */
-  template <int spacedim>
+  template <int spacedim, typename VectorType>
   void
-  set_null_space(Teuchos::ParameterList                 &parameter_list,
-                 std::unique_ptr<Epetra_MultiVector>    &ptr_distributed_modes,
-                 const Epetra_RowMatrix                 &matrix,
-                 const std::vector<std::vector<double>> &modes)
+  set_null_space(Teuchos::ParameterList              &parameter_list,
+                 std::unique_ptr<Epetra_MultiVector> &ptr_distributed_modes,
+                 const Epetra_RowMatrix              &matrix,
+                 const std::vector<VectorType>       &modes)
   {
     static_assert((spacedim == 2 || spacedim == 3),
                   "This function only works for 2D and 3D.");

--- a/include/elasticity.h
+++ b/include/elasticity.h
@@ -116,6 +116,71 @@ namespace LA
 #include <memory>
 
 
+/**
+ * Definition of the Rigid body motions for linear elasticity.
+ */
+template <int dim>
+class RigidBodyMotion : public Function<dim>
+{
+public:
+  RigidBodyMotion(const unsigned int type_);
+
+  virtual double
+  value(const Point<dim> &p, const unsigned int component) const override;
+
+private:
+  const unsigned int type;
+};
+
+
+template <int dim>
+RigidBodyMotion<dim>::RigidBodyMotion(const unsigned int _type)
+  : Function<dim>(dim)
+  , type(_type)
+{
+  Assert(dim == 2 || dim == 3, ExcNotImplemented());
+  Assert((dim == 2 && type <= 2) || (dim == 3 && type <= 5),
+         ExcNotImplemented());
+}
+
+
+
+template <int dim>
+double
+RigidBodyMotion<dim>::value(const Point<dim>  &p,
+                            const unsigned int component) const
+{
+  if constexpr (dim == 2)
+    {
+      // 2D rigid body modes: 2 translations and 1 rotation
+      const std::array<double, 3> modes{{static_cast<double>(component == 0),
+                                         static_cast<double>(component == 1),
+                                         (component == 0) ? -p[1] :
+                                         (component == 1) ? p[0] :
+                                                            0.}};
+
+      return modes[type];
+    }
+  else // dim == 3
+    {
+      // 3D rigid body modes: 3 translations and 3 rotations
+      const std::array<double, 6> modes{{static_cast<double>(component == 0),
+                                         static_cast<double>(component == 1),
+                                         static_cast<double>(component == 2),
+                                         (component == 0) ? 0. :
+                                         (component == 1) ? p[2] :
+                                                            -p[1],
+                                         (component == 0) ? -p[2] :
+                                         (component == 1) ? 0. :
+                                                            p[0],
+                                         (component == 0) ? p[1] :
+                                         (component == 1) ? -p[0] :
+                                                            0.}};
+
+      return modes[type];
+    }
+}
+
 template <int dim, int spacedim = dim>
 class ElasticityProblemParameters : public ParameterAcceptor
 {

--- a/source/elasticity.cc
+++ b/source/elasticity.cc
@@ -14,26 +14,6 @@
 //
 // ---------------------------------------------------------------------
 
-/* ---------------------------------------------------------------------
- *
- * Copyright (C) 2000 - 2020 by the deal.II authors
- *
- * This file is part of the deal.II library.
- *
- * The deal.II library is free software; you can use it, redistribute
- * it, and/or modify it under the terms of the GNU Lesser General
- * Public License as published by the Free Software Foundation; either
- * version 2.1 of the License, or (at your option) any later version.
- * The full text of the license can be found in the file LICENSE.md at
- * the top level directory of deal.II.
- *
- * ---------------------------------------------------------------------
- *
- * Author: Wolfgang Bangerth, University of Heidelberg, 2000
- * Modified by: Luca Heltai, 2020
- */
-
-
 
 #include "elasticity.h"
 
@@ -612,32 +592,39 @@ ElasticityProblem<dim, spacedim>::solve()
 #endif
 
 
-#if DEAL_II_VERSION_GTE(9, 7, 0)
-    Teuchos::ParameterList parameter_list;
+    Teuchos::ParameterList              parameter_list;
+    std::unique_ptr<Epetra_MultiVector> ptr_operator_modes;
     parameter_list.set("smoother: type", "Chebyshev");
     parameter_list.set("smoother: sweeps", 2);
     parameter_list.set("smoother: pre or post", "both");
     parameter_list.set("coarse: type", "Amesos-KLU");
     parameter_list.set("coarse: max size", 2000);
     parameter_list.set("aggregation: threshold", 0.02);
+
+#if DEAL_II_VERSION_GTE(9, 6, 0)
+    using VectorType = std::vector<double>;
     MappingQ1<spacedim>              mapping;
     std::vector<std::vector<double>> rigid_body_modes =
       DoFTools::extract_rigid_body_modes(mapping, dh);
-
-    std::unique_ptr<Epetra_MultiVector> ptr_operator_modes;
-    UtilitiesAL::set_null_space<spacedim>(parameter_list,
-                                          ptr_operator_modes,
-                                          stiffness_matrix.trilinos_matrix(),
-                                          rigid_body_modes);
-    prec_A.initialize(stiffness_matrix, parameter_list);
 #else
-    std::vector<std::vector<bool>>   constant_modes;
-    const FEValuesExtractors::Vector displacement_components(0);
-    DoFTools::extract_constant_modes(
-      dh, fe->component_mask(displacement_components), constant_modes);
-    data.constant_modes = constant_modes;
-    prec_A.initialize(stiffness_matrix, data);
+    // Ad-hoc null space for  elasticity
+    using VectorType = LinearAlgebra::distributed::Vector<double>;
+    std::vector<LinearAlgebra::distributed::Vector<double>> rigid_body_modes(
+      spacedim == 3 ? 6 : 3);
+    for (unsigned int i = 0; i < rigid_body_modes.size(); ++i)
+      {
+        rigid_body_modes[i].reinit(dh.locally_owned_dofs(), mpi_communicator);
+        RigidBodyMotion<spacedim> rbm(i);
+        VectorTools::interpolate(dh, rbm, rigid_body_modes[i]);
+      }
 #endif
+
+    UtilitiesAL::set_null_space<spacedim, VectorType>(
+      parameter_list,
+      ptr_operator_modes,
+      stiffness_matrix.trilinos_matrix(),
+      rigid_body_modes);
+    prec_A.initialize(stiffness_matrix, parameter_list);
   }
 
   const auto A    = linear_operator<LA::MPI::Vector>(stiffness_matrix);

--- a/source/elasticity.cc
+++ b/source/elasticity.cc
@@ -601,7 +601,7 @@ ElasticityProblem<dim, spacedim>::solve()
     parameter_list.set("coarse: max size", 2000);
     parameter_list.set("aggregation: threshold", 0.02);
 
-#if DEAL_II_VERSION_GTE(9, 6, 0)
+#if DEAL_II_VERSION_GTE(9, 7, 0)
     using VectorType = std::vector<double>;
     MappingQ1<spacedim>              mapping;
     std::vector<std::vector<double>> rigid_body_modes =


### PR DESCRIPTION
We will need this to invert the $(1,1)$ block of the augmented Lagrangian preconditioner using AMG (in case of linear elasticity).
The elasticity app has been updated with it just for testing. Once we have the `reduced_elasticity` in place, we can apply this to the AMG solver inside the whole AL preconditioner.

