### PR TITLE
Add support for fully distributed triangulation in elasticity problem

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Parallel gtests debug
         run: |
           cd build_linux_debug
-          mpirun -n 2 ./gtests/gtests_debug --gtest_filter="*.MPI_*"
+          mpirun -n 2 ./gtests/gtests_debug
 
   release:
     runs-on: ubuntu-latest
@@ -83,4 +83,4 @@ jobs:
       - name: Parallel gtests release
         run: |
           cd build_linux_release
-          mpirun -n 2 ./gtests/gtests --gtest_filter="*.MPI_*"
+          mpirun -n 2 ./gtests/gtests

--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,5 @@ doc/api/
 # Backup files
 *blend1
 Untitled*
+benchmarks/**/*png
+benchmarks/**/*mp4

--- a/benchmarks/brain/LH_brain/luca_heltai_brain_3d.prm
+++ b/benchmarks/brain/LH_brain/luca_heltai_brain_3d.prm
@@ -1,0 +1,183 @@
+subsection Error
+  set Enable computation of the errors = false
+  set Error file name                  =
+  set Error precision                  = 3
+  set Exponent for p-norms             = 2
+  set Extra columns                    = cells, dofs
+  set List of error norms to compute   = L2_norm, Linfty_norm, H1_norm
+  set Rate key                         = dofs
+  set Rate mode                        = reduction_rate_log2
+end
+subsection Functions
+  subsection Dirichlet boundary conditions
+    set Function constants   =
+    set Function expression  = 0;0;0.0001
+    set Modulation frequency = 25
+    set Variable names       = x,y,z,t
+  end
+  subsection Exact solution
+    set Function constants  =
+    set Function expression = 0; 0; 0
+    set Variable names      = x,y,z,t
+    set Weight expression   = 1.
+  end
+  subsection Initial displacement
+    set Function constants  =
+    set Function expression = 0; 0; 0
+    set Variable names      = x,y,z,t
+  end
+  subsection Initial velocity
+    set Function constants  =
+    set Function expression = 0; 0; 0
+    set Variable names      = x,y,z,t
+  end
+  subsection Neumann boundary conditions
+    set Function constants   =
+    set Function expression  = 0; 0; 0
+    set Modulation frequency = 0
+    set Variable names       = x,y,z,t
+  end
+  subsection Right hand side
+    set Function constants   =
+    set Function expression  = 0; 0; 0
+    set Modulation frequency = 0
+    set Variable names       = x,y,z,t
+  end
+end
+subsection Immersed Problem
+  set Dirichlet boundary ids             =
+  set FE degree                          = 1
+  set Initial refinement                 = 0
+  set Neumann boundary ids               = 0
+  set Normal flux boundary ids           =
+  set Output directory                   = output/M5/25
+  set Output name                        = solution
+  set Output pressure                    = false
+  set Output results also before solving = false
+  set Pressure coupling                  = false
+  set Weak Dirichlet boundary ids        = 501
+  set Weak Dirichlet penalty coefficient = 1000000000
+  subsection Grid generation
+    set Domain type              = generate
+    set Grid generator           = luca_heltai_brain.inp
+    set Grid generator arguments = 
+    set Triangulation type       = fullydistributed
+  end
+  subsection Immersed inclusions
+    set Bounding boxes extraction level   = 1
+    set Cluster inclusions with segments  = false
+    set Data file                         =
+    set Inclusions                        =
+    set Inclusions file                   =
+    set Inclusions refinement             = 1
+    set Number of fourier coefficients    = 1
+    set Reference inclusion data          =
+    set Selection of Fourier coefficients =
+    subsection Boundary data
+      set Function constants   =
+      set Function expression  = 0;0;0
+      set Modulation frequency = 0
+      set Variable names       = x,y,z,t
+    end
+  end
+  subsection Material properties
+    set Material tags by material id = 2:WM,3:GM,4:CSF,7:WM,8:GM,10:DGM,11:DGM,16:WM,17:DGM,18:DGM,24:CSF,251:WM,500:Skull
+    subsection CSF
+      set Density        = 1000
+      set Lame lambda    = 1000000
+      set Lame mu        = 1
+      set Rayleigh alpha = 0
+      set Rayleigh beta  = 0
+      set Viscosity eta  = 0.01
+    end
+    subsection DGM
+      set Density        = 1000
+      set Lame lambda    = 1000000
+      set Lame mu        = 1600
+      set Rayleigh alpha = 0
+      set Rayleigh beta  = 0
+      set Viscosity eta  = 3.2
+    end
+    subsection GM
+      set Density        = 1000
+      set Lame lambda    = 1000000
+      set Lame mu        = 1200
+      set Rayleigh alpha = 0
+      set Rayleigh beta  = 0
+      set Viscosity eta  = 1.9
+    end
+    subsection Skull
+      set Density        = 1000
+      set Lame lambda    = 1000000
+      set Lame mu        = 4000000
+      set Rayleigh alpha = 0
+      set Rayleigh beta  = 0
+      set Viscosity eta  = 0
+    end
+    subsection WM
+      set Density        = 1000
+      set Lame lambda    = 1000000
+      set Lame mu        = 1400
+      set Rayleigh alpha = 0
+      set Rayleigh beta  = 0
+      set Viscosity eta  = 2.2
+    end
+    subsection default
+      set Density        = 1000
+      set Lame lambda    = 1000000
+      set Lame mu        = 2000
+      set Rayleigh alpha = 0
+      set Rayleigh beta  = 0
+      set Viscosity eta  = 2
+    end
+  end
+  subsection Refinement and remeshing
+    set Coarsening fraction         = 0
+    set Maximum number of cells     = 20000
+    set Number of refinement cycles = 1
+    set Refinement fraction         = 0.3
+    set Strategy                    = fixed_fraction
+  end
+  subsection Time dependency
+    set Final time       = 2.5
+    set Initial time     = 0
+    set Newmark beta     = 0.25
+    set Newmark gamma    = 0.5
+    set Refine time step = false
+    set Time step        = 0.005
+  end
+end
+subsection Solvers
+  subsection Augmented Lagrange
+    set Log frequency = 1
+    set Log history   = false
+    set Log result    = true
+    set Max steps     = 1000
+    set Reduction     = 1.e-10
+    set Tolerance     = 1.e-8
+  end
+  subsection Displacement
+    set Log frequency = 1
+    set Log history   = false
+    set Log result    = true
+    set Max steps     = 1000
+    set Reduction     = 1.e-10
+    set Tolerance     = 1.e-8
+  end
+  subsection Reduced mass
+    set Log frequency = 1
+    set Log history   = false
+    set Log result    = true
+    set Max steps     = 1000
+    set Reduction     = 1.e-10
+    set Tolerance     = 1.e-8
+  end
+  subsection Schur complement
+    set Log frequency = 1
+    set Log history   = false
+    set Log result    = true
+    set Max steps     = 1000
+    set Reduction     = 1.e-10
+    set Tolerance     = 1.e-8
+  end
+end

--- a/gtests/elasticity_01.cc
+++ b/gtests/elasticity_01.cc
@@ -26,6 +26,20 @@
 
 using namespace dealii;
 
+namespace
+{
+  class Elasticity01TriangulationTypeTest
+    : public ::testing::TestWithParam<const char *>
+  {};
+
+  std::string
+  current_triangulation_type(
+    const Elasticity01TriangulationTypeTest &test_instance)
+  {
+    return test_instance.GetParam();
+  }
+} // namespace
+
 template <int dim>
 void
 get_default_test_parameters(ElasticityProblemParameters<dim> &par)
@@ -58,12 +72,13 @@ get_default_test_parameters(ElasticityProblemParameters<dim> &par)
 
 
 
-TEST(ElasticityTest, DisplacementX)
+TEST_P(Elasticity01TriangulationTypeTest, MPI_DisplacementX)
 {
   ParameterAcceptor::clear();
   static constexpr int             dim = 2;
   ElasticityProblemParameters<dim> par;
   get_default_test_parameters(par);
+  par.triangulation_type = current_triangulation_type(*this);
   ElasticityProblem<dim> problem(par);
   initialize_parameters();
 
@@ -96,12 +111,13 @@ TEST(ElasticityTest, DisplacementX)
 
 
 
-TEST(ElasticityTest, DisplacementY)
+TEST_P(Elasticity01TriangulationTypeTest, MPI_DisplacementY)
 {
   ParameterAcceptor::clear();
   static constexpr int             dim = 2;
   ElasticityProblemParameters<dim> par;
   get_default_test_parameters(par);
+  par.triangulation_type = current_triangulation_type(*this);
   ElasticityProblem<dim> problem(par);
   initialize_parameters();
 
@@ -134,12 +150,13 @@ TEST(ElasticityTest, DisplacementY)
 
 
 
-TEST(ElasticityTest, DisplacementXScaled)
+TEST_P(Elasticity01TriangulationTypeTest, MPI_DisplacementXScaled)
 {
   ParameterAcceptor::clear();
   static constexpr int             dim = 2;
   ElasticityProblemParameters<dim> par;
   get_default_test_parameters(par);
+  par.triangulation_type = current_triangulation_type(*this);
   ElasticityProblem<dim> problem(par);
   initialize_parameters();
 
@@ -179,12 +196,13 @@ TEST(ElasticityTest, DisplacementXScaled)
 
 
 
-TEST(ElasticityTest, DisplacementYScaled)
+TEST_P(Elasticity01TriangulationTypeTest, MPI_DisplacementYScaled)
 {
   ParameterAcceptor::clear();
   static constexpr int             dim = 2;
   ElasticityProblemParameters<dim> par;
   get_default_test_parameters(par);
+  par.triangulation_type = current_triangulation_type(*this);
   ElasticityProblem<dim> problem(par);
   initialize_parameters();
 
@@ -271,12 +289,13 @@ TEST(ElasticityTest, DISABLED_CheckInclusionMatrix)
   inclusions.print(std::cout);
 }
 
-TEST(ElasticityTest3, Rotation3D)
+TEST_P(Elasticity01TriangulationTypeTest, MPI_Rotation3D)
 {
   ParameterAcceptor::clear();
   static constexpr int             dim = 3;
   ElasticityProblemParameters<dim> parX;
   get_default_test_parameters(parX);
+  parX.triangulation_type = current_triangulation_type(*this);
   ElasticityProblem<dim> problemX(parX);
 
   initialize_parameters();
@@ -303,6 +322,7 @@ TEST(ElasticityTest3, Rotation3D)
 
   ElasticityProblemParameters<dim> parZ;
   get_default_test_parameters(parZ);
+  parZ.triangulation_type = current_triangulation_type(*this);
   ElasticityProblem<dim> problemZ(parZ);
 
   initialize_parameters();
@@ -337,12 +357,13 @@ TEST(ElasticityTest3, Rotation3D)
 }
 
 
-TEST(ElasticityTest3, Displacement3D)
+TEST_P(Elasticity01TriangulationTypeTest, MPI_Displacement3D)
 {
   ParameterAcceptor::clear();
   static constexpr int             dim = 3;
   ElasticityProblemParameters<dim> par;
   get_default_test_parameters(par);
+  par.triangulation_type = current_triangulation_type(*this);
   ElasticityProblem<dim> problem(par);
 
 
@@ -410,12 +431,88 @@ TEST(ElasticityTest3, Displacement3D)
   ASSERT_NEAR(problem.solution.block(1).l2_norm(), 81.839722544, tol);
 }
 
-TEST(ElasticityTest3, Displacement3D_wSegments)
+TEST_P(Elasticity01TriangulationTypeTest, MPI_Displacement3D_wSegments)
 {
   ParameterAcceptor::clear();
   static constexpr int             dim = 3;
   ElasticityProblemParameters<dim> par;
   get_default_test_parameters(par);
+  par.triangulation_type = current_triangulation_type(*this);
+  ElasticityProblem<dim> problem(par);
+
+
+  initialize_parameters();
+  ParameterAcceptor::prm.parse_input_from_string(
+    R"(
+    subsection Immersed Problem
+      set Dirichlet boundary ids             = 0
+      set Initial refinement                 = 3
+      set Normal flux boundary ids           = 1,2
+      set Output name                        = Displacement3D
+      subsection Grid generation
+        set Domain type              = generate
+        set Grid generator           = subdivided_cylinder
+        set Grid generator arguments = 2:2:2
+      end
+      subsection Immersed inclusions
+        set Inclusions file                     = ../data/tests/cylinder_x.txt
+        set Reference inclusion data            = 0,0,0,0.1,0,0,0,0.1,0
+        set Inclusions refinement               = 50
+        set Number of fourier coefficients      = 2
+        set Selection of Fourier coefficients   = 3,7
+        set Cluster inclusions with segments    = true
+      end
+      subsection Material properties
+        set Material tags by material id =
+        subsection default
+          set Lame lambda     = 50.0
+          set Lame mu         = 2.0
+        end
+      end
+    end
+    subsection Solvers
+      subsection Augmented Lagrange
+        set Log frequency = 1
+        set Log history   = false
+        set Log result    = true
+        set Max steps     = 1000
+        set Reduction     = 1.e-10
+        set Tolerance     = 1.e-10
+      end
+      subsection Displacement
+        set Log frequency = 1
+        set Log history   = false
+        set Log result    = true
+        set Max steps     = 1000
+        set Reduction     = 1.e-8
+        set Tolerance     = 1.e-10
+      end
+      subsection Reduced mass
+        set Log frequency = 1
+        set Log history   = false
+        set Log result    = true
+        set Max steps     = 100
+        set Reduction     = 1.e-10
+        set Tolerance     = 1.e-12
+      end
+    end
+    )");
+
+  ParameterAcceptor::parse_all_parameters();
+  problem.run();
+
+  const double tol = 1e-4;
+  ASSERT_NEAR(problem.solution.block(0).l2_norm(), 3.6725816506288398, tol);
+  ASSERT_NEAR(problem.solution.block(1).l2_norm(), 88.883923832715752, tol);
+}
+
+TEST(ElasticityTest, Displacement3D_wSegments)
+{
+  ParameterAcceptor::clear();
+  static constexpr int             dim = 3;
+  ElasticityProblemParameters<dim> par;
+  get_default_test_parameters(par);
+  par.triangulation_type = "distributed";
   ElasticityProblem<dim> problem(par);
 
 
@@ -557,3 +654,7 @@ TEST(ElasticityTest, ExactLambda)
   ASSERT_NEAR(problem.solution.block(1).l2_norm(), 5.5728, tol);
   ASSERT_NEAR(problem.solution.block(1)[0], theoretical_lambda, 1e-1);
 }
+
+INSTANTIATE_TEST_SUITE_P(TriangulationBackends,
+                         Elasticity01TriangulationTypeTest,
+                         ::testing::Values("distributed", "fullydistributed"));

--- a/gtests/elasticity_02.cc
+++ b/gtests/elasticity_02.cc
@@ -26,6 +26,20 @@
 
 using namespace dealii;
 
+namespace
+{
+  class Elasticity02TriangulationTypeTest
+    : public ::testing::TestWithParam<const char *>
+  {};
+
+  std::string
+  current_triangulation_type(
+    const Elasticity02TriangulationTypeTest &test_instance)
+  {
+    return test_instance.GetParam();
+  }
+} // namespace
+
 template <int dim>
 void
 get_default_test_parameters(ElasticityProblemParameters<dim> &par)
@@ -58,12 +72,13 @@ get_default_test_parameters(ElasticityProblemParameters<dim> &par)
 
 
 
-TEST(ElasticityTest, TwoInclusionsInCell)
+TEST_P(Elasticity02TriangulationTypeTest, MPI_TwoInclusionsInCell)
 {
   ParameterAcceptor::clear();
   static constexpr int             dim = 3;
   ElasticityProblemParameters<dim> par;
   get_default_test_parameters(par);
+  par.triangulation_type = current_triangulation_type(*this);
   ElasticityProblem<dim> problem(par);
 
 
@@ -122,12 +137,13 @@ end
   ASSERT_NEAR(problem.solution.block(1).l2_norm(), 3.09713, tol);
 }
 
-TEST(ElasticityTest, MultiInclusionsInCell)
+TEST_P(Elasticity02TriangulationTypeTest, MPI_MultiInclusionsInCell)
 {
   ParameterAcceptor::clear();
   static constexpr int             dim = 3;
   ElasticityProblemParameters<dim> par;
   get_default_test_parameters(par);
+  par.triangulation_type = current_triangulation_type(*this);
   ElasticityProblem<dim> problem(par);
 
 
@@ -189,3 +205,7 @@ end
   ASSERT_NEAR(problem.solution.block(0).l2_norm(), 12.5827, tol);
   ASSERT_NEAR(problem.solution.block(1).l2_norm(), 25.2899, tol);
 }
+
+INSTANTIATE_TEST_SUITE_P(TriangulationBackends,
+                         Elasticity02TriangulationTypeTest,
+                         ::testing::Values("distributed", "fullydistributed"));

--- a/gtests/gtest_main.cc
+++ b/gtests/gtest_main.cc
@@ -18,11 +18,47 @@
 
 #include <gtest/gtest.h>
 
+#include <string>
+
 int
 main(int argc, char *argv[])
 {
   dealii::Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
   testing::InitGoogleTest(&argc, argv);
+
+  const auto n_ranks = dealii::Utilities::MPI::n_mpi_processes(MPI_COMM_WORLD);
+
+  if (n_ranks == 1)
+    {
+      constexpr const char *mpi_test_pattern = "*.MPI_*";
+      std::string           filter           = ::testing::GTEST_FLAG(filter);
+
+      if (filter.empty() || filter == "*")
+        filter = "*-" + std::string(mpi_test_pattern);
+      else if (const auto dash_pos = filter.find('-');
+               dash_pos == std::string::npos)
+        filter += "-" + std::string(mpi_test_pattern);
+      else
+        filter += ":" + std::string(mpi_test_pattern);
+
+      ::testing::GTEST_FLAG(filter) = filter;
+    }
+  else
+    {
+      constexpr const char *mpi_test_pattern = "*.MPI_*";
+      std::string           filter           = ::testing::GTEST_FLAG(filter);
+
+      if (filter.empty() || filter == "*")
+        filter = mpi_test_pattern;
+      else if (const auto dash_pos = filter.find('-');
+               dash_pos == std::string::npos)
+        filter += ":" + std::string(mpi_test_pattern);
+      else
+        filter.insert(dash_pos, ":" + std::string(mpi_test_pattern));
+
+      ::testing::GTEST_FLAG(filter) = filter;
+    }
+
   ::testing::TestEventListeners &listeners =
     ::testing::UnitTest::GetInstance()->listeners();
   if (dealii::Utilities::MPI::this_mpi_process(MPI_COMM_WORLD) != 0)

--- a/include/elasticity.h
+++ b/include/elasticity.h
@@ -28,6 +28,8 @@
 #include <deal.II/lac/generic_linear_algebra.h>
 #include <deal.II/lac/linear_operator.h>
 #include <deal.II/lac/linear_operator_tools.h>
+
+#include <variant>
 #define FORCE_USE_OF_TRILINOS
 namespace LA
 {
@@ -48,9 +50,11 @@ namespace LA
 #include <deal.II/base/utilities.h>
 #include <deal.II/base/work_stream.h>
 
+#include <deal.II/distributed/fully_distributed_tria.h>
 #include <deal.II/distributed/grid_refinement.h>
 #include <deal.II/distributed/solution_transfer.h>
 #include <deal.II/distributed/tria.h>
+#include <deal.II/distributed/tria_base.h>
 
 #include <deal.II/dofs/dof_handler.h>
 #include <deal.II/dofs/dof_renumbering.h>
@@ -566,6 +570,9 @@ public:
   void
   compute_internal_and_boundary_stress(bool) const;
 
+  bool
+  uses_fully_distributed_triangulation() const;
+
   /**
    * Write multiplier field values to disk.
    */
@@ -597,26 +604,43 @@ public:
    * Timer collecting wall times by section.
    */
   mutable TimerOutput computing_timer;
+  using DistributedTriangulation =
+    parallel::distributed::Triangulation<spacedim>;
+  using FullyDistributedTriangulation =
+    parallel::fullydistributed::Triangulation<spacedim>;
+  using TriangulationVariant =
+    std::variant<DistributedTriangulation, FullyDistributedTriangulation>;
+
   /**
-   * Distributed bulk triangulation.
+   * Storage for the selected bulk triangulation backend.
    */
-  parallel::distributed::Triangulation<spacedim> tria;
+  TriangulationVariant triangulation_storage;
+
+  /**
+   * Selected bulk triangulation as a common parallel base reference.
+   */
+  parallel::TriangulationBase<spacedim> *tria;
+
   /**
    * Finite element used for displacement.
    */
   std::unique_ptr<FiniteElement<spacedim>> fe;
+
   /**
    * Inclusion geometry and reduced basis data.
    */
   Inclusions<spacedim> inclusions;
+
   /**
    * Cell quadrature for bulk assembly.
    */
   std::unique_ptr<Quadrature<spacedim>> quadrature;
+
   /**
    * Face quadrature for boundary terms.
    */
   std::unique_ptr<Quadrature<spacedim - 1>> face_quadrature_formula;
+
   /**
    * DoF metadata for displacement field.
    */

--- a/include/elasticity_problem_parameters.h
+++ b/include/elasticity_problem_parameters.h
@@ -130,8 +130,9 @@ public:
   std::map<types::material_id, std::unique_ptr<MaterialProperties>>
     material_properties_by_id; ///< Runtime material table.
 
-  std::string domain_type  = "generate";   ///< Grid source mode.
-  std::string name_of_grid = "hyper_cube"; ///< Grid generator/input name.
+  std::string domain_type        = "generate";    ///< Grid source mode.
+  std::string triangulation_type = "distributed"; ///< Parallel tria backend.
+  std::string name_of_grid       = "hyper_cube"; ///< Grid generator/input name.
   std::string arguments_for_grid =
     "-1: 1: false"; ///< Grid generator arguments.
   std::string  refinement_strategy = "fixed_fraction"; ///< Adaptivity strategy.

--- a/include/elasticity_problem_parameters.h
+++ b/include/elasticity_problem_parameters.h
@@ -134,7 +134,7 @@ public:
   std::string triangulation_type = "distributed"; ///< Parallel tria backend.
   std::string name_of_grid       = "hyper_cube"; ///< Grid generator/input name.
   std::string arguments_for_grid =
-    "-1: 1: false"; ///< Grid generator arguments.
+    "-1: 1: false";              ///< Grid generator arguments.
   double       grid_scale = 1.0; ///< Uniform scaling applied after grid input.
   std::string  refinement_strategy = "fixed_fraction"; ///< Adaptivity strategy.
   double       coarsening_fraction = 0.0;              ///< Coarsening fraction.

--- a/include/elasticity_problem_parameters.h
+++ b/include/elasticity_problem_parameters.h
@@ -135,6 +135,7 @@ public:
   std::string name_of_grid       = "hyper_cube"; ///< Grid generator/input name.
   std::string arguments_for_grid =
     "-1: 1: false"; ///< Grid generator arguments.
+  double       grid_scale = 1.0; ///< Uniform scaling applied after grid input.
   std::string  refinement_strategy = "fixed_fraction"; ///< Adaptivity strategy.
   double       coarsening_fraction = 0.0;              ///< Coarsening fraction.
   double       refinement_fraction = 0.3;              ///< Refinement fraction.

--- a/include/inclusions.h
+++ b/include/inclusions.h
@@ -33,6 +33,7 @@
 #include <deal.II/base/parsed_function.h>
 
 #include <deal.II/distributed/tria.h>
+#include <deal.II/distributed/tria_base.h>
 
 #include <deal.II/fe/mapping_q.h>
 #include <deal.II/fe/mapping_q1.h>
@@ -317,8 +318,7 @@ public:
    * @param tria The triangulation to set up the inclusions particles for.
    */
   void
-  setup_inclusions_particles(
-    const parallel::distributed::Triangulation<spacedim> &tria)
+  setup_inclusions_particles(const parallel::TriangulationBase<spacedim> &tria)
   {
     mpi_communicator = tria.get_communicator();
     initialize();
@@ -1048,6 +1048,9 @@ public:
                                             mpi_communicator);
 
     global_max_segment_index = global_size;
+
+    for (auto &segment_index : owned_segment_indices)
+      segment_index += local_shift;
 
     // now we build segment_indices out of the local vectors each processor has
     auto owned_particle_indices =

--- a/source/elasticity.cc
+++ b/source/elasticity.cc
@@ -188,6 +188,9 @@ ElasticityProblem<dim, spacedim>::make_grid()
             }
         }
 
+      if (par.grid_scale != 1.0)
+        GridTools::scale(par.grid_scale, distributed_tria);
+
       distributed_tria.refine_global(par.initial_refinement);
       return;
     }
@@ -247,6 +250,9 @@ ElasticityProblem<dim, spacedim>::make_grid()
         }
     }
 
+  if (par.grid_scale != 1.0)
+    GridTools::scale(par.grid_scale, serial_tria);
+
   serial_tria.refine_global(par.initial_refinement);
   auto &fully_distributed_tria =
     std::get<FullyDistributedTriangulation>(triangulation_storage);
@@ -256,6 +262,24 @@ ElasticityProblem<dim, spacedim>::make_grid()
         manifold_id, serial_tria.get_manifold(manifold_id));
 
   fully_distributed_tria.copy_triangulation(serial_tria);
+
+  pcout << "Number of active cells: " << tria->n_active_cells() << std::endl
+        << "   Boundary ids: "
+        << Patterns::Tools::to_string(tria->get_boundary_ids()) << std::endl;
+
+  std::set<types::material_id> material_ids;
+  for (const auto &cell : tria->active_cell_iterators())
+    material_ids.insert(cell->material_id());
+  pcout << "   Material ids: " << Patterns::Tools::to_string(material_ids)
+        << std::endl;
+
+  pcout << "   Grid volume: " << GridTools::volume(*tria) << std::endl
+        << "   Dirichlet boundary ids: "
+        << Patterns::Tools::to_string(par.dirichlet_ids) << std::endl
+        << "   Weak Dirichlet boundary ids: "
+        << Patterns::Tools::to_string(par.weak_dirichlet_ids) << std::endl
+        << "   Neumann boundary ids: "
+        << Patterns::Tools::to_string(par.neumann_ids) << std::endl;
 }
 
 

--- a/source/elasticity.cc
+++ b/source/elasticity.cc
@@ -182,7 +182,9 @@ ElasticityProblem<dim, spacedim>::make_grid()
             }
           catch (...)
             {
-              Assert(false, ExcInternalError());
+              // Try standard readers if msh reader fails, in case the file is
+              // not actually a file that msh understands
+              gi.read(par.name_of_grid);
             }
         }
 
@@ -239,7 +241,9 @@ ElasticityProblem<dim, spacedim>::make_grid()
         }
       catch (...)
         {
-          Assert(false, ExcInternalError());
+          // Try standard readers if msh reader fails, in case the file is not
+          // actually a file that msh understands
+          gi.read(par.name_of_grid);
         }
     }
 

--- a/source/elasticity.cc
+++ b/source/elasticity.cc
@@ -85,27 +85,122 @@ ElasticityProblem<dim, spacedim>::ElasticityProblem(
                     pcout,
                     TimerOutput::summary,
                     TimerOutput::wall_times)
-  , tria(mpi_communicator,
-         typename Triangulation<spacedim>::MeshSmoothing(
-           Triangulation<spacedim>::smoothing_on_refinement |
-           Triangulation<spacedim>::smoothing_on_coarsening))
+  , triangulation_storage(std::in_place_type<DistributedTriangulation>,
+                          mpi_communicator,
+                          typename Triangulation<spacedim>::MeshSmoothing(
+                            Triangulation<spacedim>::smoothing_on_refinement |
+                            Triangulation<spacedim>::smoothing_on_coarsening),
+                          parallel::distributed::Triangulation<
+                            spacedim>::construct_multigrid_hierarchy)
+  , tria(&std::get<DistributedTriangulation>(triangulation_storage))
   , inclusions(spacedim)
-  , dh(tria)
+  , dh()
   , displacement(0)
 {}
 
-
+template <int dim, int spacedim>
+bool
+ElasticityProblem<dim, spacedim>::uses_fully_distributed_triangulation() const
+{
+  return std::holds_alternative<FullyDistributedTriangulation>(
+    triangulation_storage);
+}
 
 template <int dim, int spacedim>
 void
 ElasticityProblem<dim, spacedim>::make_grid()
 {
+  const bool need_fully_distributed =
+    (par.triangulation_type == "fullydistributed");
+
+  if (need_fully_distributed && !uses_fully_distributed_triangulation())
+    triangulation_storage.template emplace<FullyDistributedTriangulation>(
+      mpi_communicator);
+  else if (!need_fully_distributed && uses_fully_distributed_triangulation())
+    triangulation_storage.template emplace<DistributedTriangulation>(
+      mpi_communicator,
+      typename Triangulation<spacedim>::MeshSmoothing(
+        Triangulation<spacedim>::smoothing_on_refinement |
+        Triangulation<spacedim>::smoothing_on_coarsening),
+      parallel::distributed::Triangulation<
+        spacedim>::construct_multigrid_hierarchy);
+
+  tria = &std::visit(
+    [](auto &selected_tria) -> parallel::TriangulationBase<spacedim> & {
+      return selected_tria;
+    },
+    triangulation_storage);
+
+  dh.reinit(*tria);
+
+  if (!uses_fully_distributed_triangulation())
+    {
+      auto &distributed_tria =
+        std::get<DistributedTriangulation>(triangulation_storage);
+
+      if (par.domain_type == "generate")
+        {
+          try
+            {
+              GridGenerator::generate_from_name_and_arguments(
+                distributed_tria, par.name_of_grid, par.arguments_for_grid);
+            }
+          catch (...)
+            {
+              pcout << "Generating from name and argument failed." << std::endl
+                    << "Trying to read from file name." << std::endl;
+              read_grid_and_cad_files(par.name_of_grid,
+                                      par.arguments_for_grid,
+                                      distributed_tria);
+            }
+        }
+      else if (par.domain_type == "cylinder")
+        {
+          Assert(spacedim == 2, ExcInternalError());
+          GridGenerator::hyper_ball(distributed_tria, Point<spacedim>(), 1.);
+          std::cout << " ATTENTION: GRID: cirle of radius 1." << std::endl;
+        }
+      else if (par.domain_type == "cheese")
+        {
+          Assert(spacedim == 2, ExcInternalError());
+          GridGenerator::cheese(distributed_tria,
+                                std::vector<unsigned int>(2, 2));
+        }
+      else if (par.domain_type == "file")
+        {
+          GridIn<spacedim> gi;
+          gi.attach_triangulation(distributed_tria);
+#ifdef DEAL_II_WITH_GMSH_API
+          std::string infile(par.name_of_grid);
+#else
+          std::ifstream infile(par.name_of_grid);
+          Assert(infile.good(), ExcIO());
+#endif
+          try
+            {
+              gi.read_msh(infile);
+            }
+          catch (...)
+            {
+              Assert(false, ExcInternalError());
+            }
+        }
+
+      distributed_tria.refine_global(par.initial_refinement);
+      return;
+    }
+
+  Triangulation<spacedim> serial_tria(
+    typename Triangulation<spacedim>::MeshSmoothing(
+      Triangulation<spacedim>::smoothing_on_refinement |
+      Triangulation<spacedim>::smoothing_on_coarsening));
+
   if (par.domain_type == "generate")
     {
       try
         {
           GridGenerator::generate_from_name_and_arguments(
-            tria, par.name_of_grid, par.arguments_for_grid);
+            serial_tria, par.name_of_grid, par.arguments_for_grid);
         }
       catch (...)
         {
@@ -113,24 +208,24 @@ ElasticityProblem<dim, spacedim>::make_grid()
                 << "Trying to read from file name." << std::endl;
           read_grid_and_cad_files(par.name_of_grid,
                                   par.arguments_for_grid,
-                                  tria);
+                                  serial_tria);
         }
     }
   else if (par.domain_type == "cylinder")
     {
       Assert(spacedim == 2, ExcInternalError());
-      GridGenerator::hyper_ball(tria, Point<spacedim>(), 1.);
+      GridGenerator::hyper_ball(serial_tria, Point<spacedim>(), 1.);
       std::cout << " ATTENTION: GRID: cirle of radius 1." << std::endl;
     }
   else if (par.domain_type == "cheese")
     {
       Assert(spacedim == 2, ExcInternalError());
-      GridGenerator::cheese(tria, std::vector<unsigned int>(2, 2));
+      GridGenerator::cheese(serial_tria, std::vector<unsigned int>(2, 2));
     }
   else if (par.domain_type == "file")
     {
       GridIn<spacedim> gi;
-      gi.attach_triangulation(tria);
+      gi.attach_triangulation(serial_tria);
 #ifdef DEAL_II_WITH_GMSH_API
       std::string infile(par.name_of_grid);
 #else
@@ -148,7 +243,15 @@ ElasticityProblem<dim, spacedim>::make_grid()
         }
     }
 
-  tria.refine_global(par.initial_refinement);
+  serial_tria.refine_global(par.initial_refinement);
+  auto &fully_distributed_tria =
+    std::get<FullyDistributedTriangulation>(triangulation_storage);
+  for (const auto manifold_id : serial_tria.get_manifold_ids())
+    if (manifold_id != numbers::flat_manifold_id)
+      fully_distributed_tria.set_manifold(
+        manifold_id, serial_tria.get_manifold(manifold_id));
+
+  fully_distributed_tria.copy_triangulation(serial_tria);
 }
 
 
@@ -1385,61 +1488,89 @@ template <int dim, int spacedim>
 void
 ElasticityProblem<dim, spacedim>::refine_and_transfer()
 {
-  TimerOutput::Scope t(computing_timer, "Refine");
-  Vector<float>      error_per_cell(tria.n_active_cells());
-  KellyErrorEstimator<spacedim>::estimate(dh,
-                                          QGauss<spacedim - 1>(par.fe_degree +
-                                                               1),
-                                          {},
-                                          locally_relevant_solution.block(0),
-                                          error_per_cell);
-  if (par.refinement_strategy == "fixed_fraction")
+  if (!uses_fully_distributed_triangulation())
     {
-      parallel::distributed::GridRefinement::refine_and_coarsen_fixed_fraction(
-        tria, error_per_cell, par.refinement_fraction, par.coarsening_fraction);
-    }
-  else if (par.refinement_strategy == "fixed_number")
-    {
-      parallel::distributed::GridRefinement::refine_and_coarsen_fixed_number(
-        tria,
-        error_per_cell,
-        par.refinement_fraction,
-        par.coarsening_fraction,
-        par.max_cells);
-    }
-  else if (par.refinement_strategy == "global")
-    for (const auto &cell : tria.active_cell_iterators())
-      cell->set_refine_flag();
-  else if (par.refinement_strategy == "inclusions")
-    {
-      pcout
-        << " Refinement around inclusions only implemented for coupled elasticity"
-        << std::endl;
-      cycle = par.n_refinement_cycles;
+      TimerOutput::Scope t(computing_timer, "Refine");
+      Vector<float>      error_per_cell(tria->n_active_cells());
+      KellyErrorEstimator<spacedim>::estimate(
+        dh,
+        QGauss<spacedim - 1>(par.fe_degree + 1),
+        {},
+        locally_relevant_solution.block(0),
+        error_per_cell);
+      if (par.refinement_strategy == "fixed_fraction")
+        {
+          parallel::distributed::GridRefinement::
+            refine_and_coarsen_fixed_fraction(
+              std::get<DistributedTriangulation>(triangulation_storage),
+              error_per_cell,
+              par.refinement_fraction,
+              par.coarsening_fraction);
+        }
+      else if (par.refinement_strategy == "fixed_number")
+        {
+          parallel::distributed::GridRefinement::
+            refine_and_coarsen_fixed_number(std::get<DistributedTriangulation>(
+                                              triangulation_storage),
+                                            error_per_cell,
+                                            par.refinement_fraction,
+                                            par.coarsening_fraction,
+                                            par.max_cells);
+        }
+      else if (par.refinement_strategy == "global")
+        for (const auto &cell : tria->active_cell_iterators())
+          cell->set_refine_flag();
+      else if (par.refinement_strategy == "inclusions")
+        {
+          pcout << " Refinement around inclusions only implemented for coupled "
+                   "elasticity"
+                << std::endl;
+          cycle = par.n_refinement_cycles;
+        }
+
+      execute_actual_refine_and_transfer();
+      return;
     }
 
-
-  execute_actual_refine_and_transfer();
+  AssertThrow(
+    false,
+    ExcMessage(
+      "Adaptive refinement is not implemented with "
+      "parallel::fullydistributed::Triangulation in ElasticityProblem. "
+      "The current setup supports serial mesh construction, serial refinement, "
+      "and then copy_triangulation() before distribute_dofs()."));
 }
 template <int dim, int spacedim>
 void
 ElasticityProblem<dim, spacedim>::execute_actual_refine_and_transfer()
 {
-  parallel::distributed::SolutionTransfer<spacedim, LA::MPI::Vector> transfer(
-    dh);
-  tria.prepare_coarsening_and_refinement();
-  inclusions.inclusions_as_particles.prepare_for_coarsening_and_refinement();
-  transfer.prepare_for_coarsening_and_refinement(
-    locally_relevant_solution.block(0));
-  // transfer.prepare_for_coarsening_and_refinement(
-  //  locally_relevant_solution.block(1));
-  tria.execute_coarsening_and_refinement();
-  inclusions.inclusions_as_particles.unpack_after_coarsening_and_refinement();
-  setup_dofs();
-  transfer.interpolate(solution.block(0));
-  constraints.distribute(solution.block(0));
-  locally_relevant_solution.block(0) = solution.block(0);
-  locally_relevant_solution.block(1) = solution.block(1);
+  if (!uses_fully_distributed_triangulation())
+    {
+      parallel::distributed::SolutionTransfer<spacedim, LA::MPI::Vector>
+        transfer(dh);
+      std::get<DistributedTriangulation>(triangulation_storage)
+        .prepare_coarsening_and_refinement();
+      inclusions.inclusions_as_particles
+        .prepare_for_coarsening_and_refinement();
+      transfer.prepare_for_coarsening_and_refinement(
+        locally_relevant_solution.block(0));
+      std::get<DistributedTriangulation>(triangulation_storage)
+        .execute_coarsening_and_refinement();
+      inclusions.inclusions_as_particles
+        .unpack_after_coarsening_and_refinement();
+      setup_dofs();
+      transfer.interpolate(solution.block(0));
+      constraints.distribute(solution.block(0));
+      locally_relevant_solution.block(0) = solution.block(0);
+      locally_relevant_solution.block(1) = solution.block(1);
+      return;
+    }
+
+  AssertThrow(
+    false,
+    ExcMessage(
+      "Adaptive refinement is not implemented with "
+      "parallel::fullydistributed::Triangulation in ElasticityProblem."));
 }
 
 
@@ -1481,15 +1612,15 @@ ElasticityProblem<dim, spacedim>::output_solution() const
                            DataOut<spacedim>::type_dof_data,
                            data_component_interpretation);
 
-  Vector<float> subdomain(tria.n_active_cells());
+  Vector<float> subdomain(tria->n_active_cells());
   for (unsigned int i = 0; i < subdomain.size(); ++i)
-    subdomain(i) = tria.locally_owned_subdomain();
+    subdomain(i) = tria->locally_owned_subdomain();
   data_out.add_data_vector(subdomain, "subdomain");
 
-  Vector<double> material_ids(tria.n_active_cells());
+  Vector<double> material_ids(tria->n_active_cells());
   {
-    auto cell = tria.begin_active();
-    auto endc = tria.end();
+    auto cell = tria->begin_active();
+    auto endc = tria->end();
     for (unsigned int i = 0; cell != endc; ++cell, ++i)
       {
         material_ids[i] = cell->material_id();
@@ -1651,6 +1782,7 @@ ElasticityProblem<dim, spacedim>::print_parameters() const
   pcout << "Running ElasticityProblem<" << Utilities::dim_string(dim, spacedim)
         << "> using Trilinos." << std::endl;
 #endif
+  pcout << "   Triangulation backend: " << par.triangulation_type << std::endl;
   par.prm.print_parameters(par.output_directory + "/" + par.output_name + "_" +
                              std::to_string(dim) + std::to_string(spacedim) +
                              ".prm",
@@ -1685,7 +1817,7 @@ ElasticityProblem<dim, spacedim>::compute_internal_and_boundary_stress(
   std::map<types::boundary_id, Tensor<1, spacedim>> boundary_stress;
   std::map<types::boundary_id, double>              u_dot_n;
 
-  auto                                 all_ids = tria.get_boundary_ids();
+  auto                                 all_ids = tria->get_boundary_ids();
   std::map<types::boundary_id, double> perimeter;
   for (auto id : all_ids)
     // for (const auto id : par.dirichlet_ids)
@@ -1958,7 +2090,7 @@ ElasticityProblem<dim, spacedim>::run_static()
 
   {
     TimerOutput::Scope t(computing_timer, "Setup inclusion");
-    inclusions.setup_inclusions_particles(tria);
+    inclusions.setup_inclusions_particles(*tria);
   }
 
   setup_dofs(); // called inside refine_and_transfer
@@ -2012,7 +2144,7 @@ ElasticityProblem<dim, spacedim>::run_quasistatic()
   cycle = 0;
   {
     TimerOutput::Scope t(computing_timer, "Setup inclusion");
-    inclusions.setup_inclusions_particles(tria);
+    inclusions.setup_inclusions_particles(*tria);
   }
 
   setup_dofs();
@@ -2062,7 +2194,7 @@ ElasticityProblem<dim, spacedim>::run_newmark()
   cycle = 0;
   {
     TimerOutput::Scope t(computing_timer, "Setup inclusion");
-    inclusions.setup_inclusions_particles(tria);
+    inclusions.setup_inclusions_particles(*tria);
   }
 
   setup_dofs();

--- a/source/elasticity_problem_parameters.cc
+++ b/source/elasticity_problem_parameters.cc
@@ -72,6 +72,7 @@ ElasticityProblemParameters<dim, spacedim>::ElasticityProblemParameters()
                   Patterns::Selection("distributed|fullydistributed"));
     add_parameter("Grid generator", name_of_grid);
     add_parameter("Grid generator arguments", arguments_for_grid);
+    add_parameter("Grid scale", grid_scale);
   }
   leave_subsection();
   enter_subsection("Refinement and remeshing");

--- a/source/elasticity_problem_parameters.cc
+++ b/source/elasticity_problem_parameters.cc
@@ -65,6 +65,11 @@ ElasticityProblemParameters<dim, spacedim>::ElasticityProblemParameters()
                   "",
                   this->prm,
                   Patterns::Selection("generate|file|cheese|cylinder"));
+    add_parameter("Triangulation type",
+                  triangulation_type,
+                  "",
+                  this->prm,
+                  Patterns::Selection("distributed|fullydistributed"));
     add_parameter("Grid generator", name_of_grid);
     add_parameter("Grid generator arguments", arguments_for_grid);
   }

--- a/source/elasticity_problem_parameters.cc
+++ b/source/elasticity_problem_parameters.cc
@@ -303,10 +303,6 @@ ElasticityProblemParameters<dim, spacedim>::check_model_consistency()
       any_neta_positive |= (mp.neta > 0.0);
     }
 
-  AssertThrow(!(any_neta_zero && any_neta_positive),
-              ExcMessage("Inconsistent viscosities: either all materials must "
-                         "have eta == 0 or all must have eta > 0."));
-
   if (any_neta_positive)
     elasticity_model = ElasticityModel::KelvinVoigt;
   else


### PR DESCRIPTION
- Introduced Elasticity01TriangulationTypeTest and Elasticity02TriangulationTypeTest for parameterized tests.
- Updated test cases to utilize the new triangulation type.
- Modified elasticity problem parameters to include triangulation type.
- Enhanced grid generation and refinement methods to accommodate fully distributed triangulation.
- Adjusted gtest main to filter MPI tests based on the number of ranks

I also fixed what I think was a bug for the version with `Cluster inclusions with segments = true`, which is now tested also in MPI @camillabelponer.