### PR TITLE
Add possibility to specify BC and RHS for different boundary ids and different rhs.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ jobs:
   debug:
     runs-on: ubuntu-latest
     container:
-      image: dealii/dealii:v9.6.0-noble
+      image: dealii/dealii:v9.7.1-noble
       options: --user root --env OMPI_ALLOW_RUN_AS_ROOT=1 --env OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
 
     steps:
@@ -49,7 +49,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     container:
-      image: dealii/dealii:v9.6.0-noble
+      image: dealii/dealii:v9.7.1-noble
       options: --user root --env OMPI_ALLOW_RUN_AS_ROOT=1 --env OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
 
     steps:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,8 +37,8 @@ SET(_main_target reduced_lagrange)
 # Normally you shouldn't need to change anything below.
 ############################################################
 # Declare all source files the target consists of:
-file(GLOB _files source/*cc include/*.h)
-file(GLOB _main_files apps/*cc)
+file(GLOB _files CONFIGURE_DEPENDS source/*cc include/*.h)
+file(GLOB _main_files CONFIGURE_DEPENDS apps/*cc)
 
 INCLUDE_DIRECTORIES(include)
 

--- a/README.md
+++ b/README.md
@@ -4,15 +4,9 @@
 ![Documentation](https://github.com/luca-heltai/reduced_lagrange_multipliers/actions/workflows/doxygen.yml/badge.svg)
 ![Indent](https://github.com/luca-heltai/reduced_lagrange_multipliers/actions/workflows/indentation.yml/badge.svg)
 
-This repository contains C++ implementations of reduced Lagrange multiplier methods for mixed-dimensional coupling problems, built on top of [deal.II](https://www.dealii.org).
+This repository contains C++ implementations of reduced Lagrange multiplier methods for mixed-dimensional coupling problems, built on top of [deal.II](https://www.dealii.org). Required version: 9.7.1 or later.
 
-## Overview
-
-The codebase is centered on:
-
-- bulk elasticity and Poisson solvers with immersed coupling;
-- reduced-order coupling operators and tensor-product spaces;
-- benchmark parameter sets and coupled workflows built around `deal.II`.
+The website documentation is available at <https://luca-heltai.github.io/reduced_lagrange_multipliers/>.
 
 ## Quick Start
 
@@ -21,7 +15,7 @@ mkdir -p build
 cd build
 cmake -DDEAL_II_DIR=/path/to/deal.II ..
 cmake --build . -j
-./elasticity path/to/input.prm
+./elasticity path/to/input.prm # or any other app_*.cc executable
 cd ..
 python3 -m pip install -r doc/requirements.txt
 ./scripts/build_doc.sh
@@ -39,8 +33,7 @@ python3 -m pip install -r doc/requirements.txt
 
 ## Notes
 
-- This repository may contain large benchmark/data files and local experiment artifacts.
-- Some coupled-elasticity paths depend on an external `lib1dsolver` library and related inputs under `blood/`.
+- This repository contains large benchmark/data files
 
 ## Coupled 3D/1D workflow
 

--- a/gtests/material_properties_checks.cc
+++ b/gtests/material_properties_checks.cc
@@ -22,6 +22,7 @@
 #include <gtest/gtest.h>
 
 #include <fstream>
+#include <numbers>
 #include <sstream>
 
 #include "elasticity.h"
@@ -82,4 +83,189 @@ TEST(MaterialParameters, StiffTagReadsSection)
   EXPECT_NEAR(par.material_properties_by_id.at(0)->Lame_lambda, 3.0, 1e-14);
   EXPECT_NEAR(par.material_properties_by_id.at(1)->Lame_mu, 20.0, 1e-14);
   EXPECT_NEAR(par.material_properties_by_id.at(1)->Lame_lambda, 30.0, 1e-14);
+}
+
+TEST(BoundaryConditionParameters, DirichletFallbackCopiesDefaultConfiguration)
+{
+  static constexpr int dim = 2;
+  ParameterAcceptor::clear();
+  ElasticityProblemParameters<dim> par;
+  initialize_parameters_from_string(R"(
+    subsection Immersed Problem
+      set Dirichlet boundary ids = 501
+    end
+
+    subsection Functions
+      subsection Dirichlet boundary conditions
+        set Function expression = 1 + t; 2 - x + t
+        set Modulation frequency = 2.0
+        set Phase shift = 0.3
+      end
+    end
+  )");
+
+  const auto &default_bc  = par.bc;
+  const auto &override_bc = par.get_dirichlet_bc(501);
+
+  ASSERT_EQ(par.dirichlet_bc_by_id.size(), 1);
+  ASSERT_NE(par.dirichlet_bc_by_id.at(501), nullptr);
+  EXPECT_NE(&override_bc, &default_bc);
+
+  const Point<dim> p(0.25, 0.5);
+  par.set_boundary_condition_times(0.125);
+
+  EXPECT_NEAR(override_bc.value(p, 0), default_bc.value(p, 0), 1e-14);
+  EXPECT_NEAR(override_bc.value(p, 1), default_bc.value(p, 1), 1e-14);
+  EXPECT_NEAR(override_bc.scale(0.125), default_bc.scale(0.125), 1e-14);
+}
+
+TEST(BoundaryConditionParameters, DirichletOverrideUsesBoundarySpecificSection)
+{
+  static constexpr int dim = 2;
+  ParameterAcceptor::clear();
+  ElasticityProblemParameters<dim> par;
+  initialize_parameters_from_string(R"(
+    subsection Immersed Problem
+      set Dirichlet boundary ids = 501, 502
+    end
+
+    subsection Functions
+      subsection Dirichlet boundary conditions
+        set Function expression = 1; 2
+        set Modulation frequency = 1.0
+        set Phase shift = 0.0
+      end
+      subsection Dirichlet boundary conditions 501
+        set Function expression = 10; 20
+        set Modulation frequency = 3.0
+        set Phase shift = 1.5707963267948966
+      end
+    end
+  )");
+
+  const Point<dim> p;
+  const auto      &bc_501 = par.get_dirichlet_bc(501);
+  const auto      &bc_502 = par.get_dirichlet_bc(502);
+
+  par.set_boundary_condition_times(0.0);
+
+  EXPECT_NEAR(bc_501.value(p, 0), 10.0, 1e-14);
+  EXPECT_NEAR(bc_501.value(p, 1), 20.0, 1e-14);
+  EXPECT_NEAR(bc_501.scale(0.0), 1.0, 1e-14);
+
+  EXPECT_NEAR(bc_502.value(p, 0), 1.0, 1e-14);
+  EXPECT_NEAR(bc_502.value(p, 1), 2.0, 1e-14);
+  EXPECT_NEAR(bc_502.scale(0.25), 1.0, 1e-14);
+}
+
+TEST(BoundaryConditionParameters, NeumannOverrideUsesBoundarySpecificSection)
+{
+  static constexpr int dim = 2;
+  ParameterAcceptor::clear();
+  ElasticityProblemParameters<dim> par;
+  initialize_parameters_from_string(R"(
+    subsection Immersed Problem
+      set Neumann boundary ids = 7, 8
+    end
+
+    subsection Functions
+      subsection Neumann boundary conditions
+        set Function expression = x + t; y - t
+        set Modulation frequency = 0.0
+        set Phase shift = 0.7
+      end
+      subsection Neumann boundary conditions 7
+        set Function expression = 3 * x; 4 * y
+        set Modulation frequency = 4.0
+        set Phase shift = 0.25
+      end
+    end
+  )");
+
+  const Point<dim> p(2.0, 3.0);
+  const auto      &bc_7 = par.get_neumann_bc(7);
+  const auto      &bc_8 = par.get_neumann_bc(8);
+
+  par.set_boundary_condition_times(0.5);
+
+  EXPECT_NEAR(bc_7.value(p, 0), 6.0, 1e-14);
+  EXPECT_NEAR(bc_7.value(p, 1), 12.0, 1e-14);
+  EXPECT_NEAR(bc_7.scale(0.0), std::sin(0.25), 1e-14);
+
+  EXPECT_NEAR(bc_8.value(p, 0), 2.5, 1e-14);
+  EXPECT_NEAR(bc_8.value(p, 1), 2.5, 1e-14);
+  EXPECT_NEAR(bc_8.scale(0.5), 1.0, 1e-14);
+}
+
+TEST(RhsParameters, MaterialFallbackCopiesDefaultConfiguration)
+{
+  static constexpr int dim = 2;
+  ParameterAcceptor::clear();
+  ElasticityProblemParameters<dim> par;
+  initialize_parameters_from_string(R"(
+    subsection Immersed Problem
+      set Rhs material ids = 1
+    end
+
+    subsection Functions
+      subsection Right hand side
+        set Function expression = x + t; y - t
+        set Modulation frequency = 2.0
+        set Phase shift = 0.3
+      end
+    end
+  )");
+
+  const auto &default_rhs  = par.rhs;
+  const auto &override_rhs = par.get_rhs(1);
+
+  ASSERT_EQ(par.rhs_by_material_id.size(), 1);
+  ASSERT_NE(par.rhs_by_material_id.at(1), nullptr);
+  EXPECT_NE(&override_rhs, &default_rhs);
+
+  const Point<dim> p(0.25, 0.5);
+  par.set_rhs_times(0.125);
+
+  EXPECT_NEAR(override_rhs.value(p, 0), default_rhs.value(p, 0), 1e-14);
+  EXPECT_NEAR(override_rhs.value(p, 1), default_rhs.value(p, 1), 1e-14);
+  EXPECT_NEAR(override_rhs.scale(0.125), default_rhs.scale(0.125), 1e-14);
+}
+
+TEST(RhsParameters, MaterialOverrideUsesMaterialSpecificSection)
+{
+  static constexpr int dim = 2;
+  ParameterAcceptor::clear();
+  ElasticityProblemParameters<dim> par;
+  initialize_parameters_from_string(R"(
+    subsection Immersed Problem
+      set Rhs material ids = 1, 2
+    end
+
+    subsection Functions
+      subsection Right hand side
+        set Function expression = 1; 2
+        set Modulation frequency = 1.0
+        set Phase shift = 0.0
+      end
+      subsection Right hand side 1
+        set Function expression = 10; 20
+        set Modulation frequency = 3.0
+        set Phase shift = 1.5707963267948966
+      end
+    end
+  )");
+
+  const Point<dim> p;
+  const auto      &rhs_1 = par.get_rhs(1);
+  const auto      &rhs_2 = par.get_rhs(2);
+
+  par.set_rhs_times(0.0);
+
+  EXPECT_NEAR(rhs_1.value(p, 0), 10.0, 1e-14);
+  EXPECT_NEAR(rhs_1.value(p, 1), 20.0, 1e-14);
+  EXPECT_NEAR(rhs_1.scale(0.0), 1.0, 1e-14);
+
+  EXPECT_NEAR(rhs_2.value(p, 0), 1.0, 1e-14);
+  EXPECT_NEAR(rhs_2.value(p, 1), 2.0, 1e-14);
+  EXPECT_NEAR(rhs_2.scale(0.25), 1.0, 1e-14);
 }

--- a/include/elasticity_problem_parameters.h
+++ b/include/elasticity_problem_parameters.h
@@ -80,6 +80,21 @@ public:
   const MaterialProperties &
   get_material_properties(const types::material_id material_id) const;
 
+  const ModulatedParsedFunction<spacedim> &
+  get_dirichlet_bc(const types::boundary_id boundary_id) const;
+
+  const ModulatedParsedFunction<spacedim> &
+  get_neumann_bc(const types::boundary_id boundary_id) const;
+
+  const ModulatedParsedFunction<spacedim> &
+  get_rhs(const types::material_id material_id) const;
+
+  void
+  set_rhs_times(const double time) const;
+
+  void
+  set_boundary_condition_times(const double time) const;
+
   /**
    * Check model consistency and infer derived modes after parameter parsing.
    *
@@ -129,7 +144,8 @@ public:
     material_tags_by_material_id; ///< Id->tag map.
 
   std::map<types::material_id, std::unique_ptr<MaterialProperties>>
-    material_properties_by_id; ///< Runtime material table.
+    material_properties_by_id;                     ///< Runtime material table.
+  std::set<types::material_id> rhs_material_ids{}; ///< Material-specific rhs.
 
   std::string domain_type  = "generate";   ///< Grid source mode.
   std::string name_of_grid = "hyper_cube"; ///< Grid generator/input name.
@@ -154,6 +170,9 @@ public:
    */
   /// @{
   mutable ModulatedParsedFunction<spacedim> rhs;
+  std::map<types::material_id,
+           std::shared_ptr<ModulatedParsedFunction<spacedim>>>
+    rhs_by_material_id;
   /// @}
 
   /**
@@ -179,9 +198,15 @@ public:
    */
   /// @{
   mutable ModulatedParsedFunction<spacedim> bc;
+  std::map<types::boundary_id,
+           std::shared_ptr<ModulatedParsedFunction<spacedim>>>
+    dirichlet_bc_by_id;
 
   mutable ModulatedParsedFunction<spacedim>
     Neumann_bc; ///< Neumann boundary data function.
+  std::map<types::boundary_id,
+           std::shared_ptr<ModulatedParsedFunction<spacedim>>>
+    neumann_bc_by_id;
   /// @}
 
   /**

--- a/include/elasticity_problem_parameters.h
+++ b/include/elasticity_problem_parameters.h
@@ -31,6 +31,7 @@
 #include <string>
 
 #include "material_properties.h"
+#include "modulated_parsed_function.h"
 
 /**
  * Time integration mode inferred from user parameters and material densities.
@@ -152,8 +153,7 @@ public:
    * Volumetric forcing and forcing modulation.
    */
   /// @{
-  mutable ParameterAcceptorProxy<Functions::ParsedFunction<spacedim>> rhs;
-  double rhs_modulation = 0.0; ///< Forcing modulation amplitude/factor.
+  mutable ModulatedParsedFunction<spacedim> rhs;
   /// @}
 
   /**
@@ -178,12 +178,10 @@ public:
    * Dirichlet and Neumann boundary data with modulation factors.
    */
   /// @{
-  mutable ParameterAcceptorProxy<Functions::ParsedFunction<spacedim>> bc;
-  double bc_modulation = 0.0; ///< Boundary-condition modulation factor.
+  mutable ModulatedParsedFunction<spacedim> bc;
 
-  mutable ParameterAcceptorProxy<Functions::ParsedFunction<spacedim>>
-         Neumann_bc;                  ///< Neumann boundary data function.
-  double neumann_bc_modulation = 0.0; ///< Neumann modulation factor.
+  mutable ModulatedParsedFunction<spacedim>
+    Neumann_bc; ///< Neumann boundary data function.
   /// @}
 
   /**

--- a/include/inclusions.h
+++ b/include/inclusions.h
@@ -112,6 +112,7 @@ public:
 
     enter_subsection("Boundary data");
     add_parameter("Modulation frequency", modulation_frequency);
+    add_parameter("Phase shift", phase_shift);
     leave_subsection();
 
     auto reset_function = [this]() {
@@ -1123,6 +1124,7 @@ public:
    * Frequency used to modulate inclusion boundary data in time.
    */
   double modulation_frequency = 0.0;
+  double phase_shift          = 0.0;
 
   /**
    * Particle representation of inclusion quadrature points.

--- a/include/modulated_parsed_function.h
+++ b/include/modulated_parsed_function.h
@@ -14,14 +14,29 @@ public:
   ModulatedParsedFunction(const std::string &section_name,
                           const unsigned int n_components = 1);
 
+  void
+  declare_parameters(ParameterHandler &prm) override;
+
+  void
+  parse_parameters(ParameterHandler &prm) override;
+
   double
   scale(const double time) const;
 
-  bool
-  has_zero_modulation() const;
+  void
+  copy_configuration_from(const ModulatedParsedFunction<spacedim> &other);
 
   double modulation_frequency = 0.0;
   double phase_shift          = 0.0;
+
+private:
+  void
+  parse_stored_function();
+
+  unsigned int n_components;
+  std::string  function_constants;
+  std::string  function_expression;
+  std::string  variable_names;
 };
 
 #endif

--- a/include/modulated_parsed_function.h
+++ b/include/modulated_parsed_function.h
@@ -1,0 +1,27 @@
+#ifndef reduced_lagrange_modulated_parsed_function_h
+#define reduced_lagrange_modulated_parsed_function_h
+
+#include <deal.II/base/parameter_acceptor.h>
+#include <deal.II/base/parsed_function.h>
+
+using namespace dealii;
+
+template <int spacedim>
+class ModulatedParsedFunction
+  : public ParameterAcceptorProxy<Functions::ParsedFunction<spacedim>>
+{
+public:
+  ModulatedParsedFunction(const std::string &section_name,
+                          const unsigned int n_components = 1);
+
+  double
+  scale(const double time) const;
+
+  bool
+  has_zero_modulation() const;
+
+  double modulation_frequency = 0.0;
+  double phase_shift          = 0.0;
+};
+
+#endif

--- a/source/elasticity.cc
+++ b/source/elasticity.cc
@@ -190,7 +190,10 @@ ElasticityProblem<dim, spacedim>::setup_dofs()
     DoFTools::make_hanging_node_constraints(dh, constraints);
 
     for (const auto id : par.dirichlet_ids)
-      VectorTools::interpolate_boundary_values(dh, id, par.bc, constraints);
+      VectorTools::interpolate_boundary_values(dh,
+                                               id,
+                                               par.get_dirichlet_bc(id),
+                                               constraints);
 
     std::map<types::boundary_id, const Function<spacedim, double> *>
       function_map;
@@ -198,7 +201,7 @@ ElasticityProblem<dim, spacedim>::setup_dofs()
       {
         function_map.insert(
           std::pair<types::boundary_id, const Function<spacedim, double> *>(
-            id, &par.Neumann_bc));
+            id, &par.get_neumann_bc(id)));
       }
     VectorTools::compute_nonzero_normal_flux_constraints(
       dh, 0, par.normal_flux_ids, function_map, constraints);
@@ -356,8 +359,7 @@ ElasticityProblem<dim, spacedim>::assemble_elasticity_system()
     }
 
   par.rhs.set_time(current_time);
-  par.bc.set_time(current_time);
-  par.Neumann_bc.set_time(current_time);
+  par.set_boundary_condition_times(current_time);
 
   FEValues<spacedim>     fe_values(*fe,
                                *quadrature,
@@ -462,6 +464,8 @@ ElasticityProblem<dim, spacedim>::assemble_elasticity_system()
               if (par.weak_dirichlet_ids.find(cell->face(f)->boundary_id()) !=
                   par.weak_dirichlet_ids.end())
                 {
+                  const auto &dirichlet_bc =
+                    par.get_dirichlet_bc(cell->face(f)->boundary_id());
                   fe_face_values.reinit(cell, f);
                   const auto cell_diameter = cell->diameter();
 
@@ -498,9 +502,8 @@ ElasticityProblem<dim, spacedim>::assemble_elasticity_system()
                           const auto comp_i =
                             fe->system_to_component_index(i).first;
                           Tensor<1, spacedim> g;
-                          g[comp_i] =
-                            par.bc.value(fe_face_values.quadrature_point(q),
-                                         comp_i);
+                          g[comp_i] = dirichlet_bc.value(
+                            fe_face_values.quadrature_point(q), comp_i);
 
                           cell_penalty_value_rhs(i) +=
                             par.penalty_term * (1.0 / cell_diameter) * g *
@@ -518,6 +521,8 @@ ElasticityProblem<dim, spacedim>::assemble_elasticity_system()
               else if (par.neumann_ids.find(cell->face(f)->boundary_id()) !=
                        par.neumann_ids.end())
                 {
+                  const auto &neumann_bc =
+                    par.get_neumann_bc(cell->face(f)->boundary_id());
                   fe_face_values.reinit(cell, f);
                   for (unsigned int q = 0;
                        q < fe_face_values.n_quadrature_points;
@@ -527,8 +532,9 @@ ElasticityProblem<dim, spacedim>::assemble_elasticity_system()
                         {
                           const auto comp_i =
                             fe->system_to_component_index(i).first;
-                          const auto un = par.Neumann_bc.value(
-                            fe_face_values.quadrature_point(q), comp_i);
+                          const auto un =
+                            neumann_bc.value(fe_face_values.quadrature_point(q),
+                                             comp_i);
                           cell_rhs(i) += un * fe_face_values.shape_value(i, q) *
                                          fe_face_values.JxW(q);
                         }
@@ -670,9 +676,8 @@ void
 ElasticityProblem<dim, spacedim>::assemble_forcing_terms()
 {
   const auto evaluation_time = current_time + par.dt;
-  par.rhs.set_time(evaluation_time);
-  par.bc.set_time(evaluation_time);
-  par.Neumann_bc.set_time(evaluation_time);
+  par.set_rhs_times(evaluation_time);
+  par.set_boundary_condition_times(evaluation_time);
 
   force_rhs      = 0;
   bc_rhs         = 0;
@@ -712,8 +717,10 @@ ElasticityProblem<dim, spacedim>::assemble_forcing_terms()
         cell_force_rhs      = 0;
 
         fe_values.reinit(cell);
-        par.rhs.vector_value_list(fe_values.get_quadrature_points(),
-                                  rhs_values);
+        const auto &rhs_function = par.get_rhs(cell->material_id());
+        const auto  rhs_scale    = rhs_function.scale(evaluation_time);
+        rhs_function.vector_value_list(fe_values.get_quadrature_points(),
+                                       rhs_values);
 
         // Assemble bulk contributions, no constants yet
         for (unsigned int q = 0; q < n_q_points; ++q)
@@ -721,7 +728,7 @@ ElasticityProblem<dim, spacedim>::assemble_forcing_terms()
             for (unsigned int i = 0; i < dofs_per_cell; ++i)
               {
                 const auto comp_i = fe->system_to_component_index(i).first;
-                cell_force_rhs(i) += fe_values.shape_value(i, q) *
+                cell_force_rhs(i) += rhs_scale * fe_values.shape_value(i, q) *
                                      rhs_values[q][comp_i] * fe_values.JxW(q);
               }
           }
@@ -734,6 +741,10 @@ ElasticityProblem<dim, spacedim>::assemble_forcing_terms()
               if (par.weak_dirichlet_ids.find(cell->face(f)->boundary_id()) !=
                   par.weak_dirichlet_ids.end())
                 {
+                  const auto &dirichlet_bc =
+                    par.get_dirichlet_bc(cell->face(f)->boundary_id());
+                  const auto dirichlet_scale =
+                    dirichlet_bc.scale(evaluation_time);
                   fe_face_values.reinit(cell, f);
                   const auto cell_diameter = cell->diameter();
 
@@ -755,8 +766,9 @@ ElasticityProblem<dim, spacedim>::assemble_forcing_terms()
                           const auto comp_i =
                             fe->system_to_component_index(i).first;
                           const auto g_value =
-                            par.bc.value(fe_face_values.quadrature_point(q),
-                                         comp_i);
+                            dirichlet_scale *
+                            dirichlet_bc.value(
+                              fe_face_values.quadrature_point(q), comp_i);
                           Tensor<1, spacedim> g;
                           g[comp_i] = g_value;
                           cell_bc_rhs(i) += par.penalty_term *
@@ -776,6 +788,9 @@ ElasticityProblem<dim, spacedim>::assemble_forcing_terms()
               else if (par.neumann_ids.find(cell->face(f)->boundary_id()) !=
                        par.neumann_ids.end())
                 {
+                  const auto &neumann_bc =
+                    par.get_neumann_bc(cell->face(f)->boundary_id());
+                  const auto neumann_scale = neumann_bc.scale(evaluation_time);
                   fe_face_values.reinit(cell, f);
                   for (unsigned int q = 0;
                        q < fe_face_values.n_quadrature_points;
@@ -784,8 +799,9 @@ ElasticityProblem<dim, spacedim>::assemble_forcing_terms()
                       double neumann_value = 0;
                       for (int d = 0; d < spacedim; ++d)
                         neumann_value +=
-                          par.Neumann_bc.value(
-                            fe_face_values.quadrature_point(q), d) *
+                          neumann_scale *
+                          neumann_bc.value(fe_face_values.quadrature_point(q),
+                                           d) *
                           fe_face_values.normal_vector(q)[d];
                       neumann_value /= spacedim;
                       for (unsigned int i = 0; i < dofs_per_cell; ++i)
@@ -2170,34 +2186,20 @@ ElasticityProblem<dim, spacedim>::compute_system_rhs()
                std::sin(numbers::PI * 2.0 * modulation * time + phase_shift);
     };
 
-  const bool rhs_has_any_zero_modulation = par.rhs.has_zero_modulation() ||
-                                           par.bc.has_zero_modulation() ||
-                                           par.Neumann_bc.has_zero_modulation();
-  const bool inclusion_has_zero_modulation =
-    std::abs(inclusions.modulation_frequency) == 0.0;
-
   pcout << "Time: " << current_time << std::endl;
 
-  if (rhs_has_any_zero_modulation)
-    assemble_forcing_terms();
+  assemble_forcing_terms();
+  inclusions.inclusions_rhs.set_time(current_time);
+  assemble_coupling();
 
-  if (inclusion_has_zero_modulation)
-    {
-      inclusions.inclusions_rhs.set_time(current_time);
-      assemble_coupling();
-    }
-
-  const auto rhs_scale       = par.rhs.scale(current_time);
-  const auto bc_scale        = par.bc.scale(current_time);
-  const auto neumann_scale   = par.Neumann_bc.scale(current_time);
   const auto inclusion_scale = get_scale(inclusions.modulation_frequency,
                                          inclusions.phase_shift,
                                          current_time);
 
   system_rhs.block(0) = 0.0;
-  system_rhs.block(0).add(rhs_scale, force_rhs.block(0));
-  system_rhs.block(0).add(bc_scale, bc_rhs.block(0));
-  system_rhs.block(0).add(neumann_scale, neumann_bc_rhs.block(0));
+  system_rhs.block(0).add(1.0, force_rhs.block(0));
+  system_rhs.block(0).add(1.0, bc_rhs.block(0));
+  system_rhs.block(0).add(1.0, neumann_bc_rhs.block(0));
 
   system_rhs.block(1) = force_rhs.block(1);
   system_rhs.block(1) *= inclusion_scale;

--- a/source/elasticity.cc
+++ b/source/elasticity.cc
@@ -2163,18 +2163,18 @@ template <int dim, int spacedim>
 void
 ElasticityProblem<dim, spacedim>::compute_system_rhs()
 {
-  const auto get_scale = [](const double modulation, const double time) {
-    return (modulation == 0.0) ? 1.0 :
-                                 std::sin(numbers::PI * 2 * modulation * time);
-  };
+  const auto get_scale =
+    [](const double modulation, const double phase_shift, const double time) {
+      return (modulation == 0.0) ?
+               1.0 :
+               std::sin(numbers::PI * 2.0 * modulation * time + phase_shift);
+    };
 
-  const auto is_zero = [](const double x) { return std::abs(x) == 0.0; };
-
-  const bool rhs_has_any_zero_modulation = is_zero(par.rhs_modulation) ||
-                                           is_zero(par.bc_modulation) ||
-                                           is_zero(par.neumann_bc_modulation);
+  const bool rhs_has_any_zero_modulation = par.rhs.has_zero_modulation() ||
+                                           par.bc.has_zero_modulation() ||
+                                           par.Neumann_bc.has_zero_modulation();
   const bool inclusion_has_zero_modulation =
-    is_zero(inclusions.modulation_frequency);
+    std::abs(inclusions.modulation_frequency) == 0.0;
 
   pcout << "Time: " << current_time << std::endl;
 
@@ -2187,12 +2187,12 @@ ElasticityProblem<dim, spacedim>::compute_system_rhs()
       assemble_coupling();
     }
 
-
-  const auto rhs_scale     = get_scale(par.rhs_modulation, current_time);
-  const auto bc_scale      = get_scale(par.bc_modulation, current_time);
-  const auto neumann_scale = get_scale(par.neumann_bc_modulation, current_time);
-  const auto inclusion_scale =
-    get_scale(inclusions.modulation_frequency, current_time);
+  const auto rhs_scale       = par.rhs.scale(current_time);
+  const auto bc_scale        = par.bc.scale(current_time);
+  const auto neumann_scale   = par.Neumann_bc.scale(current_time);
+  const auto inclusion_scale = get_scale(inclusions.modulation_frequency,
+                                         inclusions.phase_shift,
+                                         current_time);
 
   system_rhs.block(0) = 0.0;
   system_rhs.block(0).add(rhs_scale, force_rhs.block(0));

--- a/source/elasticity_problem_parameters.cc
+++ b/source/elasticity_problem_parameters.cc
@@ -21,6 +21,7 @@
 
 #include <filesystem>
 #include <functional>
+#include <sstream>
 #include <system_error>
 #include <vector>
 
@@ -51,6 +52,7 @@ ElasticityProblemParameters<dim, spacedim>::ElasticityProblemParameters()
   add_parameter("Weak Dirichlet penalty coefficient", penalty_term);
   add_parameter("Neumann boundary ids", neumann_ids);
   add_parameter("Normal flux boundary ids", normal_flux_ids);
+  add_parameter("Rhs material ids", rhs_material_ids);
   add_parameter("Output pressure", output_pressure);
   add_parameter(
     "Pressure coupling",
@@ -143,6 +145,151 @@ ElasticityProblemParameters<dim, spacedim>::ElasticityProblemParameters()
                              output_directory + "': " + ec.message()));
     }
 
+    bool created_dynamic_acceptors = false;
+
+    const auto split_subsection_path = [](const std::string &path) {
+      std::vector<std::string> parts;
+      std::stringstream        stream(path);
+      std::string              part;
+      while (std::getline(stream, part, '/'))
+        if (!part.empty())
+          parts.emplace_back(part);
+      return parts;
+    };
+
+    const auto get_entry_from_subsection =
+      [this, &split_subsection_path](const std::string &path,
+                                     const std::string &entry) {
+        const auto subsections = split_subsection_path(path);
+        for (const auto &subsection : subsections)
+          this->prm.enter_subsection(subsection);
+        const auto value = this->prm.get(entry);
+        for (unsigned int i = 0; i < subsections.size(); ++i)
+          this->prm.leave_subsection();
+        return value;
+      };
+
+    const auto set_entry_in_subsection =
+      [this, &split_subsection_path](const std::string &path,
+                                     const std::string &entry,
+                                     const std::string &value) {
+        const auto subsections = split_subsection_path(path);
+        for (const auto &subsection : subsections)
+          this->prm.enter_subsection(subsection);
+        this->prm.set(entry, value);
+        for (unsigned int i = 0; i < subsections.size(); ++i)
+          this->prm.leave_subsection();
+      };
+
+    const auto ensure_boundary_condition_overrides =
+      [this,
+       &created_dynamic_acceptors,
+       &get_entry_from_subsection,
+       &set_entry_in_subsection](const std::set<types::boundary_id> &ids,
+                                 auto                               &map,
+                                 const std::string                  &prefix) {
+        for (const auto id : ids)
+          if (map.find(id) == map.end())
+            {
+              const auto override_section =
+                prefix + " " + std::to_string(static_cast<unsigned int>(id));
+              auto ptr = std::make_shared<ModulatedParsedFunction<spacedim>>(
+                override_section, spacedim);
+              ptr->enter_my_subsection(this->prm);
+              ptr->declare_parameters(this->prm);
+              ptr->leave_my_subsection(this->prm);
+              set_entry_in_subsection(
+                override_section,
+                "Function constants",
+                get_entry_from_subsection(prefix, "Function constants"));
+              set_entry_in_subsection(
+                override_section,
+                "Function expression",
+                get_entry_from_subsection(prefix, "Function expression"));
+              set_entry_in_subsection(
+                override_section,
+                "Variable names",
+                get_entry_from_subsection(prefix, "Variable names"));
+              set_entry_in_subsection(
+                override_section,
+                "Modulation frequency",
+                get_entry_from_subsection(prefix, "Modulation frequency"));
+              set_entry_in_subsection(override_section,
+                                      "Phase shift",
+                                      get_entry_from_subsection(prefix,
+                                                                "Phase shift"));
+              map[id]                   = ptr;
+              created_dynamic_acceptors = true;
+            }
+      };
+
+    const auto ensure_rhs_overrides =
+      [this,
+       &created_dynamic_acceptors,
+       &get_entry_from_subsection,
+       &set_entry_in_subsection](const std::set<types::material_id> &ids,
+                                 auto                               &map,
+                                 const std::string                  &prefix) {
+        for (const auto id : ids)
+          if (map.find(id) == map.end())
+            {
+              const auto override_section =
+                prefix + " " + std::to_string(static_cast<unsigned int>(id));
+              auto ptr = std::make_shared<ModulatedParsedFunction<spacedim>>(
+                override_section, spacedim);
+              ptr->enter_my_subsection(this->prm);
+              ptr->declare_parameters(this->prm);
+              ptr->leave_my_subsection(this->prm);
+              set_entry_in_subsection(
+                override_section,
+                "Function constants",
+                get_entry_from_subsection(prefix, "Function constants"));
+              set_entry_in_subsection(
+                override_section,
+                "Function expression",
+                get_entry_from_subsection(prefix, "Function expression"));
+              set_entry_in_subsection(
+                override_section,
+                "Variable names",
+                get_entry_from_subsection(prefix, "Variable names"));
+              set_entry_in_subsection(
+                override_section,
+                "Modulation frequency",
+                get_entry_from_subsection(prefix, "Modulation frequency"));
+              set_entry_in_subsection(override_section,
+                                      "Phase shift",
+                                      get_entry_from_subsection(prefix,
+                                                                "Phase shift"));
+              map[id]                   = ptr;
+              created_dynamic_acceptors = true;
+            }
+      };
+
+    {
+      this->leave_my_subsection(this->prm);
+
+      ensure_rhs_overrides(rhs_material_ids,
+                           rhs_by_material_id,
+                           "/Functions/Right hand side");
+
+      std::set<types::boundary_id> dirichlet_bc_ids = dirichlet_ids;
+      dirichlet_bc_ids.insert(weak_dirichlet_ids.begin(),
+                              weak_dirichlet_ids.end());
+      ensure_boundary_condition_overrides(
+        dirichlet_bc_ids,
+        dirichlet_bc_by_id,
+        "/Functions/Dirichlet boundary conditions");
+
+      std::set<types::boundary_id> neumann_bc_ids = neumann_ids;
+      neumann_bc_ids.insert(normal_flux_ids.begin(), normal_flux_ids.end());
+      ensure_boundary_condition_overrides(
+        neumann_bc_ids,
+        neumann_bc_by_id,
+        "/Functions/Neumann boundary conditions");
+
+      this->enter_my_subsection(this->prm);
+    }
+
     // Ensure material properties acceptors exist when material tags are
     // provided. This is needed for the two-pass initialization strategy:
     // - pass 1: read tags, create acceptors
@@ -173,6 +320,9 @@ ElasticityProblemParameters<dim, spacedim>::ElasticityProblemParameters()
         check_model_consistency();
         return;
       }
+
+    if (created_dynamic_acceptors)
+      return;
 
     // No dynamic material tags: all information is already available.
     check_model_consistency();
@@ -305,6 +455,75 @@ ElasticityProblemParameters<dim, spacedim>::get_material_properties(
     return *(it->second);
   else
     return default_material_properties;
+}
+
+template <int dim, int spacedim>
+const ModulatedParsedFunction<spacedim> &
+ElasticityProblemParameters<dim, spacedim>::get_dirichlet_bc(
+  const types::boundary_id boundary_id) const
+{
+  const auto it = dirichlet_bc_by_id.find(boundary_id);
+  if (it != dirichlet_bc_by_id.end())
+    return *(it->second);
+
+  return bc;
+}
+
+template <int dim, int spacedim>
+const ModulatedParsedFunction<spacedim> &
+ElasticityProblemParameters<dim, spacedim>::get_neumann_bc(
+  const types::boundary_id boundary_id) const
+{
+  const auto it = neumann_bc_by_id.find(boundary_id);
+  if (it != neumann_bc_by_id.end())
+    return *(it->second);
+
+  return Neumann_bc;
+}
+
+template <int dim, int spacedim>
+const ModulatedParsedFunction<spacedim> &
+ElasticityProblemParameters<dim, spacedim>::get_rhs(
+  const types::material_id material_id) const
+{
+  const auto it = rhs_by_material_id.find(material_id);
+  if (it != rhs_by_material_id.end())
+    return *(it->second);
+
+  return rhs;
+}
+
+template <int dim, int spacedim>
+void
+ElasticityProblemParameters<dim, spacedim>::set_rhs_times(
+  const double time) const
+{
+  rhs.set_time(time);
+  for (const auto &[id, ptr] : rhs_by_material_id)
+    {
+      (void)id;
+      ptr->set_time(time);
+    }
+}
+
+template <int dim, int spacedim>
+void
+ElasticityProblemParameters<dim, spacedim>::set_boundary_condition_times(
+  const double time) const
+{
+  bc.set_time(time);
+  for (const auto &[id, ptr] : dirichlet_bc_by_id)
+    {
+      (void)id;
+      ptr->set_time(time);
+    }
+
+  Neumann_bc.set_time(time);
+  for (const auto &[id, ptr] : neumann_bc_by_id)
+    {
+      (void)id;
+      ptr->set_time(time);
+    }
 }
 
 

--- a/source/elasticity_problem_parameters.cc
+++ b/source/elasticity_problem_parameters.cc
@@ -105,34 +105,20 @@ ElasticityProblemParameters<dim, spacedim>::ElasticityProblemParameters()
   // Make sure all functions have reasonable defaults, and add their modulation
   // frequencies
   {
-    const auto set_modulation = [this](auto &acceptor, auto &arg) {
-      acceptor.declare_parameters_call_back.connect([this, &arg]() {
-        this->prm.add_parameter("Modulation frequency", arg);
-      });
-    };
-
     auto reset_function = [this]() {
       this->prm.declare_entry(
         "Function expression",
         (spacedim == 2 ? "0; 0" : "0; 0; 0"),
         Patterns::List(Patterns::Anything(), spacedim, spacedim, ";"));
     };
-    rhs.declare_parameters_call_back.connect(reset_function);
-    set_modulation(rhs, rhs_modulation);
 
     exact_solution.declare_parameters_call_back.connect(reset_function);
     exact_solution.declare_parameters_call_back.connect([this]() {
       this->prm.add_parameter("Weight expression", weight_expression);
     });
 
-    Neumann_bc.declare_parameters_call_back.connect(reset_function);
-    set_modulation(Neumann_bc, neumann_bc_modulation);
-
     initial_displacement.declare_parameters_call_back.connect(reset_function);
     initial_velocity.declare_parameters_call_back.connect(reset_function);
-
-    bc.declare_parameters_call_back.connect(reset_function);
-    set_modulation(bc, bc_modulation);
   }
   {
     auto reduction = [&]() {

--- a/source/elasticity_problem_parameters.cc
+++ b/source/elasticity_problem_parameters.cc
@@ -157,37 +157,58 @@ ElasticityProblemParameters<dim, spacedim>::ElasticityProblemParameters()
       return parts;
     };
 
+    struct SubsectionScope
+    {
+      SubsectionScope(ParameterHandler               &prm,
+                      const std::vector<std::string> &subsections)
+        : prm(prm)
+        , n_subsections(subsections.size())
+      {
+        for (const auto &subsection : subsections)
+          prm.enter_subsection(subsection);
+      }
+
+      ~SubsectionScope()
+      {
+        for (unsigned int i = 0; i < n_subsections; ++i)
+          prm.leave_subsection();
+      }
+
+      ParameterHandler &prm;
+      unsigned int      n_subsections;
+    };
+
     const auto get_entry_from_subsection =
       [this, &split_subsection_path](const std::string &path,
                                      const std::string &entry) {
-        const auto subsections = split_subsection_path(path);
-        for (const auto &subsection : subsections)
-          this->prm.enter_subsection(subsection);
-        const auto value = this->prm.get(entry);
-        for (unsigned int i = 0; i < subsections.size(); ++i)
-          this->prm.leave_subsection();
-        return value;
+        const SubsectionScope scope(this->prm, split_subsection_path(path));
+        return this->prm.get(entry);
       };
 
     const auto set_entry_in_subsection =
       [this, &split_subsection_path](const std::string &path,
                                      const std::string &entry,
                                      const std::string &value) {
-        const auto subsections = split_subsection_path(path);
-        for (const auto &subsection : subsections)
-          this->prm.enter_subsection(subsection);
+        const SubsectionScope scope(this->prm, split_subsection_path(path));
         this->prm.set(entry, value);
-        for (unsigned int i = 0; i < subsections.size(); ++i)
-          this->prm.leave_subsection();
       };
 
-    const auto ensure_boundary_condition_overrides =
-      [this,
-       &created_dynamic_acceptors,
-       &get_entry_from_subsection,
-       &set_entry_in_subsection](const std::set<types::boundary_id> &ids,
-                                 auto                               &map,
-                                 const std::string                  &prefix) {
+    const auto copy_modulated_function_entries =
+      [&get_entry_from_subsection,
+       &set_entry_in_subsection](const std::string &from_section,
+                                 const std::string &to_section) {
+        for (const auto &entry : {"Function constants",
+                                  "Function expression",
+                                  "Variable names",
+                                  "Modulation frequency",
+                                  "Phase shift"})
+          set_entry_in_subsection(
+            to_section, entry, get_entry_from_subsection(from_section, entry));
+      };
+
+    const auto ensure_function_overrides =
+      [this, &created_dynamic_acceptors, &copy_modulated_function_entries](
+        const auto &ids, auto &map, const std::string &prefix) {
         for (const auto id : ids)
           if (map.find(id) == map.end())
             {
@@ -198,68 +219,7 @@ ElasticityProblemParameters<dim, spacedim>::ElasticityProblemParameters()
               ptr->enter_my_subsection(this->prm);
               ptr->declare_parameters(this->prm);
               ptr->leave_my_subsection(this->prm);
-              set_entry_in_subsection(
-                override_section,
-                "Function constants",
-                get_entry_from_subsection(prefix, "Function constants"));
-              set_entry_in_subsection(
-                override_section,
-                "Function expression",
-                get_entry_from_subsection(prefix, "Function expression"));
-              set_entry_in_subsection(
-                override_section,
-                "Variable names",
-                get_entry_from_subsection(prefix, "Variable names"));
-              set_entry_in_subsection(
-                override_section,
-                "Modulation frequency",
-                get_entry_from_subsection(prefix, "Modulation frequency"));
-              set_entry_in_subsection(override_section,
-                                      "Phase shift",
-                                      get_entry_from_subsection(prefix,
-                                                                "Phase shift"));
-              map[id]                   = ptr;
-              created_dynamic_acceptors = true;
-            }
-      };
-
-    const auto ensure_rhs_overrides =
-      [this,
-       &created_dynamic_acceptors,
-       &get_entry_from_subsection,
-       &set_entry_in_subsection](const std::set<types::material_id> &ids,
-                                 auto                               &map,
-                                 const std::string                  &prefix) {
-        for (const auto id : ids)
-          if (map.find(id) == map.end())
-            {
-              const auto override_section =
-                prefix + " " + std::to_string(static_cast<unsigned int>(id));
-              auto ptr = std::make_shared<ModulatedParsedFunction<spacedim>>(
-                override_section, spacedim);
-              ptr->enter_my_subsection(this->prm);
-              ptr->declare_parameters(this->prm);
-              ptr->leave_my_subsection(this->prm);
-              set_entry_in_subsection(
-                override_section,
-                "Function constants",
-                get_entry_from_subsection(prefix, "Function constants"));
-              set_entry_in_subsection(
-                override_section,
-                "Function expression",
-                get_entry_from_subsection(prefix, "Function expression"));
-              set_entry_in_subsection(
-                override_section,
-                "Variable names",
-                get_entry_from_subsection(prefix, "Variable names"));
-              set_entry_in_subsection(
-                override_section,
-                "Modulation frequency",
-                get_entry_from_subsection(prefix, "Modulation frequency"));
-              set_entry_in_subsection(override_section,
-                                      "Phase shift",
-                                      get_entry_from_subsection(prefix,
-                                                                "Phase shift"));
+              copy_modulated_function_entries(prefix, override_section);
               map[id]                   = ptr;
               created_dynamic_acceptors = true;
             }
@@ -268,24 +228,22 @@ ElasticityProblemParameters<dim, spacedim>::ElasticityProblemParameters()
     {
       this->leave_my_subsection(this->prm);
 
-      ensure_rhs_overrides(rhs_material_ids,
-                           rhs_by_material_id,
-                           "/Functions/Right hand side");
+      ensure_function_overrides(rhs_material_ids,
+                                rhs_by_material_id,
+                                "/Functions/Right hand side");
 
       std::set<types::boundary_id> dirichlet_bc_ids = dirichlet_ids;
       dirichlet_bc_ids.insert(weak_dirichlet_ids.begin(),
                               weak_dirichlet_ids.end());
-      ensure_boundary_condition_overrides(
-        dirichlet_bc_ids,
-        dirichlet_bc_by_id,
-        "/Functions/Dirichlet boundary conditions");
+      ensure_function_overrides(dirichlet_bc_ids,
+                                dirichlet_bc_by_id,
+                                "/Functions/Dirichlet boundary conditions");
 
       std::set<types::boundary_id> neumann_bc_ids = neumann_ids;
       neumann_bc_ids.insert(normal_flux_ids.begin(), normal_flux_ids.end());
-      ensure_boundary_condition_overrides(
-        neumann_bc_ids,
-        neumann_bc_by_id,
-        "/Functions/Neumann boundary conditions");
+      ensure_function_overrides(neumann_bc_ids,
+                                neumann_bc_by_id,
+                                "/Functions/Neumann boundary conditions");
 
       this->enter_my_subsection(this->prm);
     }

--- a/source/modulated_parsed_function.cc
+++ b/source/modulated_parsed_function.cc
@@ -1,0 +1,43 @@
+#include "modulated_parsed_function.h"
+
+#include <deal.II/base/numbers.h>
+#include <deal.II/base/patterns.h>
+
+#include <cmath>
+
+template <int spacedim>
+ModulatedParsedFunction<spacedim>::ModulatedParsedFunction(
+  const std::string &section_name,
+  const unsigned int n_components)
+  : ParameterAcceptorProxy<Functions::ParsedFunction<spacedim>>(section_name,
+                                                                n_components)
+{
+  this->declare_parameters_call_back.connect([this]() {
+    this->prm.declare_entry(
+      "Function expression",
+      (spacedim == 2 ? "0; 0" : "0; 0; 0"),
+      Patterns::List(Patterns::Anything(), spacedim, spacedim, ";"));
+    this->prm.add_parameter("Modulation frequency", modulation_frequency);
+    this->prm.add_parameter("Phase shift", phase_shift);
+  });
+}
+
+template <int spacedim>
+double
+ModulatedParsedFunction<spacedim>::scale(const double time) const
+{
+  return (modulation_frequency == 0.0) ?
+           1.0 :
+           std::sin(numbers::PI * 2.0 * modulation_frequency * time +
+                    phase_shift);
+}
+
+template <int spacedim>
+bool
+ModulatedParsedFunction<spacedim>::has_zero_modulation() const
+{
+  return std::abs(modulation_frequency) == 0.0;
+}
+
+template class ModulatedParsedFunction<2>;
+template class ModulatedParsedFunction<3>;

--- a/source/modulated_parsed_function.cc
+++ b/source/modulated_parsed_function.cc
@@ -1,5 +1,6 @@
 #include "modulated_parsed_function.h"
 
+#include <deal.II/base/exceptions.h>
 #include <deal.II/base/numbers.h>
 #include <deal.II/base/patterns.h>
 
@@ -11,15 +12,41 @@ ModulatedParsedFunction<spacedim>::ModulatedParsedFunction(
   const unsigned int n_components)
   : ParameterAcceptorProxy<Functions::ParsedFunction<spacedim>>(section_name,
                                                                 n_components)
+  , n_components(n_components)
+  , function_expression(spacedim == 2 ? "0; 0" : "0; 0; 0")
+  , variable_names(spacedim == 1 ? "x,t" :
+                   spacedim == 2 ? "x,y,t" :
+                                   "x,y,z,t")
+{}
+
+template <int spacedim>
+void
+ModulatedParsedFunction<spacedim>::declare_parameters(ParameterHandler &prm)
 {
-  this->declare_parameters_call_back.connect([this]() {
-    this->prm.declare_entry(
-      "Function expression",
-      (spacedim == 2 ? "0; 0" : "0; 0; 0"),
-      Patterns::List(Patterns::Anything(), spacedim, spacedim, ";"));
-    this->prm.add_parameter("Modulation frequency", modulation_frequency);
-    this->prm.add_parameter("Phase shift", phase_shift);
-  });
+  Functions::ParsedFunction<spacedim>::declare_parameters(prm,
+                                                          n_components,
+                                                          function_expression);
+  prm.add_parameter("Modulation frequency", modulation_frequency);
+  prm.add_parameter("Phase shift", phase_shift);
+}
+
+template <int spacedim>
+void
+ModulatedParsedFunction<spacedim>::parse_parameters(ParameterHandler &prm)
+{
+  try
+    {
+      function_constants  = prm.get("Function constants");
+      function_expression = prm.get("Function expression");
+      variable_names      = prm.get("Variable names");
+      Functions::ParsedFunction<spacedim>::parse_parameters(prm);
+    }
+  catch (const dealii::ExceptionBase &)
+    {
+      // Dynamically created acceptors are instantiated during the first
+      // parameter pass and only declare their entries on the second pass.
+      // Ignore the intermediate parse and let the second pass populate them.
+    }
 }
 
 template <int spacedim>
@@ -33,11 +60,32 @@ ModulatedParsedFunction<spacedim>::scale(const double time) const
 }
 
 template <int spacedim>
-bool
-ModulatedParsedFunction<spacedim>::has_zero_modulation() const
+void
+ModulatedParsedFunction<spacedim>::copy_configuration_from(
+  const ModulatedParsedFunction<spacedim> &other)
 {
-  return std::abs(modulation_frequency) == 0.0;
+  modulation_frequency = other.modulation_frequency;
+  phase_shift          = other.phase_shift;
+  function_constants   = other.function_constants;
+  function_expression  = other.function_expression;
+  variable_names       = other.variable_names;
+  parse_stored_function();
 }
 
+template <int spacedim>
+void
+ModulatedParsedFunction<spacedim>::parse_stored_function()
+{
+  ParameterHandler prm;
+  Functions::ParsedFunction<spacedim>::declare_parameters(prm,
+                                                          n_components,
+                                                          function_expression);
+  prm.set("Function constants", function_constants);
+  prm.set("Function expression", function_expression);
+  prm.set("Variable names", variable_names);
+  Functions::ParsedFunction<spacedim>::parse_parameters(prm);
+}
+
+template class ModulatedParsedFunction<1>;
 template class ModulatedParsedFunction<2>;
 template class ModulatedParsedFunction<3>;

--- a/source/vtk_utils.cc
+++ b/source/vtk_utils.cc
@@ -23,7 +23,6 @@
 #  include <deal.II/grid/tria_iterator.h>
 
 #  include <vtkCellData.h>
-#  include <vtkCleanUnstructuredGrid.h>
 #  include <vtkDataArray.h>
 #  include <vtkPointData.h>
 #  include <vtkSmartPointer.h>
@@ -45,18 +44,6 @@ namespace VTKUtils
     reader->Update();
     vtkUnstructuredGrid *grid = reader->GetOutput();
     AssertThrow(grid, ExcMessage("Failed to read VTK file: " + vtk_filename));
-
-    auto cleaner = vtkSmartPointer<vtkCleanUnstructuredGrid>::New();
-
-    // Cleanup the triangulation if requested
-    if (cleanup)
-      {
-        cleaner->SetInputData(grid);
-        cleaner->Update();
-        grid = cleaner->GetOutput();
-        AssertThrow(grid,
-                    ExcMessage("Failed to clean VTK file: " + vtk_filename));
-      }
 
     // Read points
     vtkPoints                   *vtk_points = grid->GetPoints();


### PR DESCRIPTION
This PR refactors `elasticity` parameter handling to support id-specific functions, cleaner modulation handling, and runtime selection of the triangulation backend in MPI.

Main changes:
- introduced `ModulatedParsedFunction`, a wrapper around `ParsedFunction` that manages:
  - `Function expression`
  - `Modulation frequency`
  - `Phase shift`
- refactored boundary conditions to support default sections plus per-id overrides:
  - `Dirichlet boundary conditions`
  - `Dirichlet boundary conditions <boundary_id>`
  - `Neumann boundary conditions`
  - `Neumann boundary conditions <boundary_id>`
- extended the same pattern to the volume `rhs` using `material_id`:
  - `Right hand side`
  - `Right hand side <material_id>`
- added `Rhs material ids`, empty by default
- `rhs`, Dirichlet, and Neumann modulation are now applied directly during assembly, removing the previous special-case logic based on “zero modulation”
- added targeted tests to verify:
  - fallback to default sections
  - boundary-id overrides
  - material-id overrides
  - correct two-pass parsing for dynamically created acceptors

Example parameter file:

```prm
subsection Immersed Problem
  set Triangulation type = fullydistributed
  set Rhs material ids   = 1, 5
  set Weak Dirichlet boundary ids = 10, 20
  set Neumann boundary ids = 30
end

subsection Functions
  subsection Right hand side
    set Function expression = 0; -1; 0
    set Modulation frequency = 2.0
    set Phase shift = 0.0
  end

  subsection Right hand side 5
    set Function expression = 0; -5; 0
    set Modulation frequency = 1.0
    set Phase shift = 1.57079632679
  end

  subsection Dirichlet boundary conditions
    set Function expression = 0; 0; 0
  end

  subsection Dirichlet boundary conditions 20
    set Function expression = 0.1; 0; 0
    set Modulation frequency = 3.0
    set Phase shift = 0.5
  end

  subsection Neumann boundary conditions
    set Function expression = 0; 0; 1
  end
end
```

Behavior in this example:
- all materials use the default `rhs`, except material `5`
- all weak Dirichlet boundaries use the default function, except boundary `20`
- modulation is applied directly during assembly, with no separate zero-modulation path
